### PR TITLE
Higher precision for floats in range [0,1)

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -23,10 +23,10 @@ fn distr_baseline(b: &mut Bencher) {
 
     b.iter(|| {
         for _ in 0..::RAND_BENCH_N {
-            f64::rand(&mut rng, Default);
+            u64::rand(&mut rng, Default);
         }
     });
-    b.bytes = size_of::<f64>() as u64 * ::RAND_BENCH_N;
+    b.bytes = size_of::<u64>() as u64 * ::RAND_BENCH_N;
 }
 
 

--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -10,7 +10,7 @@ use test::{black_box, Bencher};
 use rand::StdRng;
 use rand::prng::XorShiftRng;
 use rand::sequences::{sample, Shuffle};
-use rand::distributions::{Rand, Uniform, Uniform01};
+use rand::distributions::{Rand, Uniform, Uniform01, Closed01, Open01};
 
 #[bench]
 fn misc_baseline_32(b: &mut Bencher) {
@@ -35,7 +35,7 @@ fn misc_baseline_64(b: &mut Bencher) {
 }
 
 #[bench]
-fn misc_convert_f32(b: &mut Bencher) {
+fn misc_uniform01_f32(b: &mut Bencher) {
     let mut rng = StdRng::new().unwrap();
     b.iter(|| {
         for _ in 0..RAND_BENCH_N {
@@ -46,11 +46,55 @@ fn misc_convert_f32(b: &mut Bencher) {
 }
 
 #[bench]
-fn misc_convert_f64(b: &mut Bencher) {
+fn misc_uniform01_f64(b: &mut Bencher) {
     let mut rng = StdRng::new().unwrap();
     b.iter(|| {
         for _ in 0..RAND_BENCH_N {
             black_box(f64::rand(&mut rng, Uniform01));
+        }
+    });
+    b.bytes = size_of::<f64>() as u64 * RAND_BENCH_N;
+}
+
+#[bench]
+fn misc_closed01_f32(b: &mut Bencher) {
+    let mut rng = StdRng::new().unwrap();
+    b.iter(|| {
+        for _ in 0..RAND_BENCH_N {
+            black_box(f32::rand(&mut rng, Closed01));
+        }
+    });
+    b.bytes = size_of::<f32>() as u64 * RAND_BENCH_N;
+}
+
+#[bench]
+fn misc_closed01_f64(b: &mut Bencher) {
+    let mut rng = StdRng::new().unwrap();
+    b.iter(|| {
+        for _ in 0..RAND_BENCH_N {
+            black_box(f64::rand(&mut rng, Closed01));
+        }
+    });
+    b.bytes = size_of::<f64>() as u64 * RAND_BENCH_N;
+}
+
+#[bench]
+fn misc_open01_f32(b: &mut Bencher) {
+    let mut rng = StdRng::new().unwrap();
+    b.iter(|| {
+        for _ in 0..RAND_BENCH_N {
+            black_box(f32::rand(&mut rng, Open01));
+        }
+    });
+    b.bytes = size_of::<f32>() as u64 * RAND_BENCH_N;
+}
+
+#[bench]
+fn misc_open01_f64(b: &mut Bencher) {
+    let mut rng = StdRng::new().unwrap();
+    b.iter(|| {
+        for _ in 0..RAND_BENCH_N {
+            black_box(f64::rand(&mut rng, Open01));
         }
     });
     b.bytes = size_of::<f64>() as u64 * RAND_BENCH_N;

--- a/src/distributions/float_conversions.rs
+++ b/src/distributions/float_conversions.rs
@@ -1,0 +1,246 @@
+// Copyright 2017 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Convert a random int to a float in the range [0,1]
+
+use core::mem;
+
+trait FloatBitOps {
+    type F;
+
+    /// Helper function to combine the fraction, exponent and sign into a float.
+    /// `self` includes the bits from the fraction and sign.
+    fn binor_exp(self, exponent: i32) -> Self::F;
+}
+
+impl FloatBitOps for u32 {
+    type F = f32;
+    #[inline(always)]
+    fn binor_exp(self, exponent: i32) -> f32 {
+        // The exponent is encoded using an offset-binary representation,
+        // with the zero offset being 127
+        let exponent_bits = ((127 + exponent) as u32) << 23;
+        unsafe { mem::transmute(self | exponent_bits) }
+    }
+}
+
+impl FloatBitOps for u64 {
+    type F = f64;
+    #[inline(always)]
+    fn binor_exp(self, exponent: i32) -> f64 {
+        // The exponent is encoded using an offset-binary representation,
+        // with the zero offset being 1023
+        let exponent_bits = ((1023 + exponent) as u64) << 52;
+        unsafe { mem::transmute(self | exponent_bits) }
+    }
+}
+
+pub trait FloatConversions {
+    type F;
+
+    /// Convert a random number to a floating point number sampled from the
+    /// uniformly distributed half-open range [0,1).
+    /// Closer to zero the distribution gains more precision, up to
+    /// 2^-32 for f32 and 2^-64 for f64.
+    fn uniform01(self) -> Self::F;
+
+    /// Convert a random number to a floating point number sampled from the
+    /// uniformly distributed closed range [0,1].
+    /// Closer to zero the distribution gains more precision, up to
+    /// 2^-32 for f32 and 2^-64 for f64.
+    fn closed01(self) -> Self::F;
+
+    /// Convert a random number to a floating point number sampled from the
+    /// uniformly distributed half-open range [-1,1).
+    /// Closer to zero the distribution gains more precision, up to
+    /// 2^-32 for f32 and 2^-64 for f64.
+    fn uniform11(self) -> Self::F;
+}
+
+macro_rules! float_impls {
+    ($ty:ty, $uty:ty, $FLOAT_SIZE:expr, $FRACTION_BITS:expr,
+     $FRACTION_MASK:expr, $next_u:path) => {
+
+        impl FloatConversions for $uty {
+            type F = $ty;
+
+            /// Convert a random number to a floating point number sampled from
+            /// the uniformly distributed half-open range [0,1).
+            ///
+            /// We fill the fractional part of the f32 with 23 random bits.
+            /// The trick to generate a uniform distribution over [0,1) is to
+            /// fill the exponent with the -log2 of the remaining random bits. A
+            /// simpler alternative to -log2 is to count the number of trailing
+            /// zero's of the random bits, add 1, and negate the result.
+            ///
+            /// Each exponent is responsible for a piece of the distribution
+            /// between [0,1). The exponent -1 fills the part [0.5,1). -2 fills
+            /// [0.25,0.5). The lowest exponent we can get is -10. So a problem
+            /// with this method is that we can not fill the part between zero
+            /// and the part from -10. The solution is to treat numbers with an
+            /// exponent of -10 as if they have -9 as exponent, and substract
+            /// 2^-9.
+            #[inline(always)]
+            fn uniform01(self) -> $ty {
+                const MIN_EXPONENT: i32 = $FRACTION_BITS - $FLOAT_SIZE;
+                #[allow(non_snake_case)]
+                let ADJUST: $ty = (0 as $uty).binor_exp(MIN_EXPONENT);
+                                  // 2^MIN_EXPONENT
+
+                // Use the last 23 bits to fill the fraction
+                let fraction = self & $FRACTION_MASK;
+                // Use the remaing (first) 9 bits for the exponent
+                let exp = $FRACTION_BITS - 1
+                          - ((self & !$FRACTION_MASK).trailing_zeros() as i32);
+                if exp < MIN_EXPONENT {
+                    return fraction.binor_exp(MIN_EXPONENT) - ADJUST;
+                }
+                fraction.binor_exp(exp)
+            }
+
+            /// Convert a random number to a floating point number sampled from
+            /// the uniformly distributed closed range [0,1].
+            ///
+            /// The problem with a closed range over [0,1] is that the chance to
+            /// sample 1.0 exactly is 2^n+1. Which is difficult, as it is not a
+            /// power of two. Instead of a closed range, we actually sample from
+            /// the half-open range (0,1].
+            ///
+            /// Floating-point numbers have more precision near zero. This means
+            /// for a f32 that only 1 in 2^32 samples will give exactly 0.0. But
+            /// 1 in 2^23 will give exactly 1.0 due to rounding. Because the
+            /// chance to sample 0.0 is so low, this half-open range is a very
+            /// good appoximation of a closed range.
+            ///
+            /// This method is similar to `Uniform01`, with one extra step:
+            /// If the fractional part ends up as zero, add 1 to the exponent in
+            /// 50% of the cases. This changes 0.5 to 1.0, 0.25 to 0.5, etc.
+            ///
+            /// The chance to select these numbers that staddle the boundery
+            /// between exponents is 33% to high in `Uniform01` (e.g. 33%*2^-23
+            /// for 0.5f32). The reason is that with 0.5 as example the distance
+            /// to the next number is 2^-23, but to the previous number 2^-24.
+            /// With the adjustment they have exactly the right chance of
+            /// getting sampled.
+            #[inline(always)]
+            fn closed01(self) -> $ty {
+                const MIN_EXPONENT: i32 = $FRACTION_BITS - $FLOAT_SIZE;
+                #[allow(non_snake_case)]
+                let ADJUST: $ty = (0 as $uty).binor_exp(MIN_EXPONENT);
+                                  // 2^MIN_EXPONENT
+
+                // Use the last 23 bits to fill the fraction
+                let fraction = self & $FRACTION_MASK;
+                // Use the remaing (first) 9 bits for the exponent
+                let mut exp = $FRACTION_BITS - 1
+                              - ((self & !$FRACTION_MASK).trailing_zeros() as i32);
+                if fraction == 0 {
+                    // Shift the exponent in about 50% of the samples, based on
+                    // one of the unused bits for the exponent.
+                    // Shift uncondinionally for the lowest exponents, because
+                    // there are no more random bits left.
+                    if (exp > MIN_EXPONENT) &&
+                       (self & 1 << ($FLOAT_SIZE - 1) != 0) {
+                        exp += 1;
+                    }
+                } else if exp < MIN_EXPONENT {
+                    return fraction.binor_exp(MIN_EXPONENT) - ADJUST;
+                }
+                fraction.binor_exp(exp)
+            }
+
+            /// Convert a random number to a floating point number sampled from
+            /// the uniformly distributed half-open range [-1,1).
+            ///
+            /// This uses the same method as `uniform01`. One of the random bits
+            /// that it uses for the exponent, is now used as a sign bit.
+            ///
+            /// This samples numbers from the range (-1,-0] and [0,1). Ideally
+            /// we would not sample -0.0, but include -1.0. That is why for
+            /// negative numbers we use the extra step from `open01`.
+            #[inline(always)]
+            fn uniform11(self) -> $ty {
+                const MIN_EXPONENT: i32 = $FRACTION_BITS - $FLOAT_SIZE + 1;
+                const SIGN_BIT: $uty = 1 << ($FLOAT_SIZE - 1);
+                #[allow(non_snake_case)]
+                let ADJUST: $ty = (0 as $uty).binor_exp(MIN_EXPONENT);
+                                  // 2^MIN_EXPONENT
+
+                // Use the last 23 bits to fill the fraction, and the first bit
+                // as sign
+                let fraction = self & ($FRACTION_MASK | SIGN_BIT);
+                // Use the remaing 8 bits for the exponent
+                let mut exp = $FRACTION_BITS -
+                              (((self & !$FRACTION_MASK) << 1).trailing_zeros() as i32);
+                if fraction == SIGN_BIT {
+                    // Shift the exponent in about 50% of the samples, based on
+                    // one of the unused bits for the exponent.
+                    // Shift uncondinionally for the lowest exponents, because
+                    // there are no more random bits left.
+                    if (exp > MIN_EXPONENT) &&
+                       (self & 1 << ($FLOAT_SIZE - 2) != 0) {
+                        exp += 1;
+                    }
+                } else if exp < MIN_EXPONENT {
+                    let result: $ty = fraction.binor_exp(MIN_EXPONENT);
+                    match fraction & SIGN_BIT == SIGN_BIT {
+                        false => return result - ADJUST,
+                        true => return result + ADJUST,
+                    };
+                }
+                fraction.binor_exp(exp)
+            }
+        }
+    }
+}
+float_impls! { f32, u32, 32, 23, 0x7FFFFF, Rng::next_u32 }
+float_impls! { f64, u64, 64, 52, 0xFFFFFFFFFFFFF, Rng::next_u64 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::FloatConversions;
+
+    #[test]
+    fn uniform01_edge_cases() {
+        // Test that the distribution is a half-open range over [0,1).
+        // These constants happen to generate the lowest and highest floats in
+        // the range.
+        assert!(0u32.uniform01() == 0.0);
+        assert!(0xffff_ffffu32.uniform01() == 0.99999994);
+
+        assert!(0u64.uniform01() == 0.0);
+        assert!(0xffff_ffff_ffff_ffffu64.uniform01() == 0.9999999999999999);
+    }
+
+    #[test]
+    fn closed01_edge_cases() {
+        // Test that the distribution is a half-open range over (0,1].
+        // These constants happen to generate the lowest and highest floats in
+        // the range.
+        assert!(1u32.closed01() == 2.3283064e-10); // 2^-32
+        assert!(0xff80_0000u32.closed01() == 1.0);
+
+        assert!(1u64.closed01() == 5.421010862427522e-20); // 2^-64
+        assert!(0xfff0_0000_0000_0000u64.closed01() == 1.0);
+    }
+
+    #[test]
+    fn uniform11_edge_cases() {
+        // Test that the distribution is a half-open range over [-1,1).
+        // These constants happen to generate the lowest and highest floats in
+        // the range.
+        assert!(0xff80_0000u32.uniform11() == -1.0);
+        assert!(0x7fff_ffffu32.uniform11() == 0.99999994);
+
+        assert!(0xfff0_0000_0000_0000u64.uniform11() == -1.0);
+        assert!(0x7fff_ffff_ffff_ffffu64.uniform11() == 0.9999999999999999);
+    }
+}

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -37,6 +37,7 @@ mod default;
 mod uniform;
 #[cfg(feature="std")]
 mod ziggurat_tables;
+mod float_conversions;
 
 pub mod range;
 pub mod range2;

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -23,7 +23,7 @@ pub use self::default::Default;
 pub use self::uniform::{uniform, codepoint, ascii_word_char};
 pub use self::uniform::{Uniform, Uniform01, Open01, Closed01, AsciiWordChar};
 pub use self::range::{Range};
-use self::float_conversions::FloatConversions;
+use utils::FloatConversions;
 
 #[cfg(feature="std")]
 pub use self::gamma::{Gamma, ChiSquared, FisherF, StudentT};
@@ -38,7 +38,6 @@ mod default;
 mod uniform;
 #[cfg(feature="std")]
 mod ziggurat_tables;
-mod float_conversions;
 
 pub mod range;
 pub mod range2;
@@ -173,9 +172,9 @@ fn ziggurat<R: Rng+?Sized, P, Z>(
         // FIXME: the distribution is not open, but closed-open.
         //        Can that cause problems or a bias?
         let u = if symmetric {
-                    bits.uniform11_simple()
+                    bits.closed_open11_fixed()
                 } else {
-                    bits.uniform01_simple()
+                    bits.closed_open01_fixed()
                 };
         let i = (bits & 0xff) as usize;
 

--- a/src/distributions/range2.rs
+++ b/src/distributions/range2.rs
@@ -25,7 +25,7 @@ use core::num::Wrapping as w;
 
 use Rng;
 use distributions::Distribution;
-use distributions::float_conversions::FloatConversions;
+use utils::FloatConversions;
 
 /// Sample values uniformly between two bounds.
 ///
@@ -206,14 +206,14 @@ macro_rules! range_float_impl {
             // simple as applying a scale and offset to get the right range.
             // For a negative range, we apply a negative scale to transform the
             // range [0,1) to (-x,0]. Because this results in a range with it
-            // closed and open sides reversed, we do not sample from `Uniform01`
-            // but from `Closed01`, which actually returns samples from the
-            // range (0,1].
+            // closed and open sides reversed, we do not sample from
+            // `closed_open01` but from `open_closed01`.
             //
             // A range that is both negative and positive.
             // This range has as characteristic that it does not have most of
             // its bits of precision near its low or high end, but in the middle
-            // near 0.0. As the basis we use the [-1,1) range from `Uniform11`.
+            // near 0.0. As the basis we use the [-1,1) range from
+            // `closed_open11`.
             // How it works is easiest to explain with an example.
             // Suppose we want to sample from the range [-20, 100). We are
             // first going to scale the range from [-1,1) to (-60,60]. Note the
@@ -255,15 +255,15 @@ macro_rules! range_float_impl {
                 let rnd = $next_u(rng);
                 match *self {
                     RangeFloat::Positive { offset, scale } => {
-                        let x: $ty = rnd.uniform01();
+                        let x: $ty = rnd.closed_open01();
                         offset + scale * x
                     }
                     RangeFloat::Negative { offset, scale } => {
-                        let x: $ty = rnd.closed01();
+                        let x: $ty = rnd.open_closed01();
                         offset + scale * x
                     }
                     RangeFloat::PosAndNeg { cutoff, scale } => {
-                        let x: $ty = rnd.uniform11();
+                        let x: $ty = rnd.closed_open11();
                         let x = x * scale;
                         if x < cutoff {
                             (cutoff - scale) - x
@@ -272,7 +272,7 @@ macro_rules! range_float_impl {
                         }
                     }
                     RangeFloat::NegAndPos { cutoff, scale } => {
-                        let x: $ty = rnd.uniform11();
+                        let x: $ty = rnd.closed_open11();
                         let x = x * scale;
                         if x >= cutoff {
                             (cutoff + scale) - x

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ pub mod iter;
 pub mod prng;
 pub mod reseeding;
 pub mod sequences;
+pub mod utils;
 
 #[cfg(feature="std")]
 mod os;


### PR DESCRIPTION
First a disclaimer :).
With all the discussions happening around rand, I am not sure where to open a pull request.
Also it is a bit difficult for me to explain what I am doing here...

This commit changes the way floats are created with the distribution `Uniform01`.
This is not a method I have found anywhere else, but loosely inspired by
https://readings.owlfolio.org/2007/generating-pseudorandom-floating-point-values/ .

With this method floats have a much better precision near zero (9 extra bits of precision for f32, and 12 extra bits for f64).

It seems to have almost no influence on the benchmarks:
before:
`test distr_baseline          ... bench:       1,616 ns/iter (+/- 68) = 4950 MB/s`
after:
`test distr_baseline          ... bench:       1,621 ns/iter (+/- 30) = 4935 MB/s`