### PR TITLE
Isaac refactoring

### DIFF
--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -10,8 +10,6 @@
 
 //! The ISAAC random number generator.
 
-#![allow(non_camel_case_types)]
-
 use core::slice;
 use core::iter::repeat;
 use core::num::Wrapping as w;
@@ -19,12 +17,11 @@ use core::fmt;
 
 use {Rng, FromRng, SeedableRng};
 
-#[allow(bad_style)]
+#[allow(non_camel_case_types)]
 type w32 = w<u32>;
 
 const RAND_SIZE_LEN: usize = 8;
-const RAND_SIZE: u32 = 1 << RAND_SIZE_LEN;
-const RAND_SIZE_USIZE: usize = 1 << RAND_SIZE_LEN;
+const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 
 /// A random number generator that uses the ISAAC algorithm[1].
 ///
@@ -37,18 +34,18 @@ const RAND_SIZE_USIZE: usize = 1 << RAND_SIZE_LEN;
 /// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
 #[derive(Copy)]
 pub struct IsaacRng {
-    cnt: u32,
-    rsl: [w32; RAND_SIZE_USIZE],
-    mem: [w32; RAND_SIZE_USIZE],
+    rsl: [w32; RAND_SIZE],
+    mem: [w32; RAND_SIZE],
     a: w32,
     b: w32,
     c: w32,
+    cnt: u32,
 }
 
 static EMPTY: IsaacRng = IsaacRng {
     cnt: 0,
-    rsl: [w(0); RAND_SIZE_USIZE],
-    mem: [w(0); RAND_SIZE_USIZE],
+    rsl: [w(0); RAND_SIZE],
+    mem: [w(0); RAND_SIZE],
     a: w(0), b: w(0), c: w(0),
 };
 
@@ -65,7 +62,7 @@ impl IsaacRng {
     /// of `rsl` as a seed, otherwise construct one algorithmically (not
     /// randomly).
     fn init(&mut self, use_rsl: bool) {
-        let mut a = w(0x9e3779b9);
+        let mut a = w(0x9e3779b9); // golden ratio
         let mut b = a;
         let mut c = a;
         let mut d = a;
@@ -76,14 +73,14 @@ impl IsaacRng {
 
         macro_rules! mix {
             () => {{
-                a=a^(b<<11); d=d+a; b=b+c;
-                b=b^(c>>2);  e=e+b; c=c+d;
-                c=c^(d<<8);  f=f+c; d=d+e;
-                d=d^(e>>16); g=g+d; e=e+f;
-                e=e^(f<<10); h=h+e; f=f+g;
-                f=f^(g>>4);  a=a+f; g=g+h;
-                g=g^(h<<8);  b=b+g; h=h+a;
-                h=h^(a>>9);  c=c+h; a=a+b;
+                a ^= b << 11; d += a; b += c;
+                b ^= c >> 2;  e += b; c += d;
+                c ^= d << 8;  f += c; d += e;
+                d ^= e >> 16; g += d; e += f;
+                e ^= f << 10; h += e; f += g;
+                f ^= g >> 4;  a += f; g += h;
+                g ^= h << 8;  b += g; h += a;
+                h ^= a >> 9;  c += h; a += b;
             }}
         }
 
@@ -94,16 +91,16 @@ impl IsaacRng {
         if use_rsl {
             macro_rules! memloop {
                 ($arr:expr) => {{
-                    for i in (0..RAND_SIZE_USIZE/8).map(|i| i * 8) {
-                        a=a+$arr[i  ]; b=b+$arr[i+1];
-                        c=c+$arr[i+2]; d=d+$arr[i+3];
-                        e=e+$arr[i+4]; f=f+$arr[i+5];
-                        g=g+$arr[i+6]; h=h+$arr[i+7];
+                    for i in (0..RAND_SIZE/8).map(|i| i * 8) {
+                        a += $arr[i  ]; b += $arr[i+1];
+                        c += $arr[i+2]; d += $arr[i+3];
+                        e += $arr[i+4]; f += $arr[i+5];
+                        g += $arr[i+6]; h += $arr[i+7];
                         mix!();
-                        self.mem[i  ]=a; self.mem[i+1]=b;
-                        self.mem[i+2]=c; self.mem[i+3]=d;
-                        self.mem[i+4]=e; self.mem[i+5]=f;
-                        self.mem[i+6]=g; self.mem[i+7]=h;
+                        self.mem[i  ] = a; self.mem[i+1] = b;
+                        self.mem[i+2] = c; self.mem[i+3] = d;
+                        self.mem[i+4] = e; self.mem[i+5] = f;
+                        self.mem[i+6] = g; self.mem[i+7] = h;
                     }
                 }}
             }
@@ -111,12 +108,12 @@ impl IsaacRng {
             memloop!(self.rsl);
             memloop!(self.mem);
         } else {
-            for i in (0..RAND_SIZE_USIZE/8).map(|i| i * 8) {
+            for i in (0..RAND_SIZE/8).map(|i| i * 8) {
                 mix!();
-                self.mem[i  ]=a; self.mem[i+1]=b;
-                self.mem[i+2]=c; self.mem[i+3]=d;
-                self.mem[i+4]=e; self.mem[i+5]=f;
-                self.mem[i+6]=g; self.mem[i+7]=h;
+                self.mem[i  ] = a; self.mem[i+1] = b;
+                self.mem[i+2] = c; self.mem[i+3] = d;
+                self.mem[i+4] = e; self.mem[i+5] = f;
+                self.mem[i+6] = g; self.mem[i+7] = h;
             }
         }
 
@@ -124,63 +121,56 @@ impl IsaacRng {
     }
 
     /// Refills the output buffer (`self.rsl`)
-    #[inline]
     fn isaac(&mut self) {
-        self.c = self.c + w(1);
+        self.c += w(1);
         // abbreviations
         let mut a = self.a;
         let mut b = self.b + self.c;
+        const MIDPOINT: usize = RAND_SIZE / 2;
 
-        const MIDPOINT: usize = RAND_SIZE_USIZE / 2;
-
-        macro_rules! ind {
-            ($x:expr) => ( self.mem[($x >> 2usize).0 as usize & (RAND_SIZE_USIZE - 1)] )
+        #[inline(always)]
+        fn ind(mem:&[w32; RAND_SIZE], v: w32, amount: usize) -> w32 {
+            let index = (v >> amount).0 as usize % RAND_SIZE;
+            mem[index]
         }
 
-        let r = [(0, MIDPOINT), (MIDPOINT, 0)];
-        for &(mr_offset, m2_offset) in r.iter() {
+        #[inline(always)]
+        fn rngstep(ctx: &mut IsaacRng,
+                   mix: w32,
+                   a: &mut w32,
+                   b: &mut w32,
+                   base: usize,
+                   m: usize,
+                   m2: usize) {
+            let x = ctx.mem[base + m];
+            *a = mix + ctx.mem[base + m2];
+            let y = *a + *b + ind(&ctx.mem, x, 2);
+            ctx.mem[base + m] = y;
+            *b = x + ind(&ctx.mem, y, 2 + RAND_SIZE_LEN);
+            ctx.rsl[base + m] = *b;
+        }
 
-            macro_rules! rngstepp {
-                ($j:expr, $shift:expr) => {{
-                    let base = $j;
-                    let mix = a << $shift;
+        let mut m = 0;
+        let mut m2 = MIDPOINT;
+        for i in (0..MIDPOINT/4).map(|i| i * 4) {
+            rngstep(self, a ^ (a << 13), &mut a, &mut b, i + 0, m, m2);
+            rngstep(self, a ^ (a >> 6 ),  &mut a, &mut b, i + 1, m, m2);
+            rngstep(self, a ^ (a << 2 ),  &mut a, &mut b, i + 2, m, m2);
+            rngstep(self, a ^ (a >> 16),  &mut a, &mut b, i + 3, m, m2);
+        }
 
-                    let x = self.mem[base  + mr_offset];
-                    a = (a ^ mix) + self.mem[base + m2_offset];
-                    let y = ind!(x) + a + b;
-                    self.mem[base + mr_offset] = y;
-
-                    b = ind!(y >> RAND_SIZE_LEN) + x;
-                    self.rsl[base + mr_offset] = b;
-                }}
-            }
-
-            macro_rules! rngstepn {
-                ($j:expr, $shift:expr) => {{
-                    let base = $j;
-                    let mix = a >> $shift;
-
-                    let x = self.mem[base  + mr_offset];
-                    a = (a ^ mix) + self.mem[base + m2_offset];
-                    let y = ind!(x) + a + b;
-                    self.mem[base + mr_offset] = y;
-
-                    b = ind!(y >> RAND_SIZE_LEN) + x;
-                    self.rsl[base + mr_offset] = b;
-                }}
-            }
-
-            for i in (0..MIDPOINT/4).map(|i| i * 4) {
-                rngstepp!(i + 0, 13);
-                rngstepn!(i + 1, 6);
-                rngstepp!(i + 2, 2);
-                rngstepn!(i + 3, 16);
-            }
+        m = MIDPOINT;
+        m2 = 0;
+        for i in (0..MIDPOINT/4).map(|i| i * 4) {
+            rngstep(self, a ^ (a << 13), &mut a, &mut b, i + 0, m, m2);
+            rngstep(self, a ^ (a >> 6 ),  &mut a, &mut b, i + 1, m, m2);
+            rngstep(self, a ^ (a << 2 ),  &mut a, &mut b, i + 2, m, m2);
+            rngstep(self, a ^ (a >> 16),  &mut a, &mut b, i + 3, m, m2);
         }
 
         self.a = a;
         self.b = b;
-        self.cnt = RAND_SIZE;
+        self.cnt = RAND_SIZE as u32;
     }
 }
 
@@ -206,12 +196,12 @@ impl Rng for IsaacRng {
         // misrefactors, so we check, sometimes.
         //
         // (Changes here should be reflected in Isaac64Rng.next_u64.)
-        debug_assert!(self.cnt < RAND_SIZE);
+        debug_assert!((self.cnt as usize) < RAND_SIZE);
 
         // (the % is cheaply telling the optimiser that we're always
         // in bounds, without unsafe. NB. this is a power of two, so
         // it optimises to a bitwise mask).
-        self.rsl[(self.cnt % RAND_SIZE) as usize].0
+        self.rsl[self.cnt as usize % RAND_SIZE].0
     }
 }
 
@@ -221,7 +211,7 @@ impl FromRng for IsaacRng {
         unsafe {
             let ptr = ret.rsl.as_mut_ptr() as *mut u8;
 
-            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE_USIZE * 4);
+            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE * 4);
             other.fill_bytes(slice);
         }
         ret.cnt = 0;

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -19,14 +19,6 @@ use core::fmt;
 
 use {Rng, FromRng, SeedableRng};
 
-/// Select 32- or 64-bit variant dependent on pointer size.
-#[cfg(target_pointer_width = "32")]
-pub use prng::IsaacRng as IsaacWordRng;
-#[cfg(target_pointer_width = "64")]
-pub use prng::Isaac64Rng as IsaacWordRng;
-
-#[allow(bad_style)]
-type w64 = w<u64>;
 #[allow(bad_style)]
 type w32 = w<u32>;
 
@@ -277,273 +269,17 @@ impl fmt::Debug for IsaacRng {
     }
 }
 
-const RAND_SIZE_64_LEN: usize = 8;
-const RAND_SIZE_64: usize = 1 << RAND_SIZE_64_LEN;
-
-/// A random number generator that uses ISAAC-64[1], the 64-bit
-/// variant of the ISAAC algorithm.
-///
-/// The ISAAC algorithm is generally accepted as suitable for
-/// cryptographic purposes, but this implementation has not be
-/// verified as such. Prefer a generator like `OsRng` that defers to
-/// the operating system for cases that need high security.
-///
-/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
-/// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
-#[derive(Copy)]
-pub struct Isaac64Rng {
-    cnt: usize,
-    rsl: [w64; RAND_SIZE_64],
-    mem: [w64; RAND_SIZE_64],
-    a: w64,
-    b: w64,
-    c: w64,
-}
-
-static EMPTY_64: Isaac64Rng = Isaac64Rng {
-    cnt: 0,
-    rsl: [w(0); RAND_SIZE_64],
-    mem: [w(0); RAND_SIZE_64],
-    a: w(0), b: w(0), c: w(0),
-};
-
-impl Isaac64Rng {
-    /// Create a 64-bit ISAAC random number generator using the
-    /// default fixed seed.
-    pub fn new_unseeded() -> Isaac64Rng {
-        let mut rng = EMPTY_64;
-        rng.init(false);
-        rng
-    }
-
-    /// Initialises `self`. If `use_rsl` is true, then use the current value
-    /// of `rsl` as a seed, otherwise construct one algorithmically (not
-    /// randomly).
-    fn init(&mut self, use_rsl: bool) {
-        macro_rules! init {
-            ($var:ident) => (
-                let mut $var = w(0x9e3779b97f4a7c13);
-            )
-        }
-        init!(a); init!(b); init!(c); init!(d);
-        init!(e); init!(f); init!(g); init!(h);
-
-        macro_rules! mix {
-            () => {{
-                a=a-e; f=f^(h>>9);  h=h+a;
-                b=b-f; g=g^(a<<9);  a=a+b;
-                c=c-g; h=h^(b>>23); b=b+c;
-                d=d-h; a=a^(c<<15); c=c+d;
-                e=e-a; b=b^(d>>14); d=d+e;
-                f=f-b; c=c^(e<<20); e=e+f;
-                g=g-c; d=d^(f>>17); f=f+g;
-                h=h-d; e=e^(g<<14); g=g+h;
-            }}
-        }
-
-        for _ in 0..4 {
-            mix!();
-        }
-
-        if use_rsl {
-            macro_rules! memloop {
-                ($arr:expr) => {{
-                    for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
-                        a=a+$arr[i  ]; b=b+$arr[i+1];
-                        c=c+$arr[i+2]; d=d+$arr[i+3];
-                        e=e+$arr[i+4]; f=f+$arr[i+5];
-                        g=g+$arr[i+6]; h=h+$arr[i+7];
-                        mix!();
-                        self.mem[i  ]=a; self.mem[i+1]=b;
-                        self.mem[i+2]=c; self.mem[i+3]=d;
-                        self.mem[i+4]=e; self.mem[i+5]=f;
-                        self.mem[i+6]=g; self.mem[i+7]=h;
-                    }
-                }}
-            }
-
-            memloop!(self.rsl);
-            memloop!(self.mem);
-        } else {
-            for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
-                mix!();
-                self.mem[i  ]=a; self.mem[i+1]=b;
-                self.mem[i+2]=c; self.mem[i+3]=d;
-                self.mem[i+4]=e; self.mem[i+5]=f;
-                self.mem[i+6]=g; self.mem[i+7]=h;
-            }
-        }
-
-        self.isaac64();
-    }
-
-    /// Refills the output buffer (`self.rsl`)
-    fn isaac64(&mut self) {
-        self.c = self.c + w(1);
-        // abbreviations
-        let mut a = self.a;
-        let mut b = self.b + self.c;
-        const MIDPOINT: usize =  RAND_SIZE_64 / 2;
-        const MP_VEC: [(usize, usize); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
-        macro_rules! ind {
-            ($x:expr) => {
-                *self.mem.get_unchecked((($x >> 3usize).0 as usize) & (RAND_SIZE_64 - 1))
-            }
-        }
-
-        for &(mr_offset, m2_offset) in MP_VEC.iter() {
-            for base in (0..MIDPOINT / 4).map(|i| i * 4) {
-
-                macro_rules! rngstepp {
-                    ($j:expr, $shift:expr) => {{
-                        let base = base + $j;
-                        let mix = a ^ (a << $shift);
-                        let mix = if $j == 0 {!mix} else {mix};
-
-                        unsafe {
-                            let x = *self.mem.get_unchecked(base + mr_offset);
-                            a = mix + *self.mem.get_unchecked(base + m2_offset);
-                            let y = ind!(x) + a + b;
-                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
-
-                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
-                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
-                        }
-                    }}
-                }
-
-                macro_rules! rngstepn {
-                    ($j:expr, $shift:expr) => {{
-                        let base = base + $j;
-                        let mix = a ^ (a >> $shift);
-                        let mix = if $j == 0 {!mix} else {mix};
-
-                        unsafe {
-                            let x = *self.mem.get_unchecked(base + mr_offset);
-                            a = mix + *self.mem.get_unchecked(base + m2_offset);
-                            let y = ind!(x) + a + b;
-                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
-
-                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
-                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
-                        }
-                    }}
-                }
-
-                rngstepp!(0, 21);
-                rngstepn!(1, 5);
-                rngstepp!(2, 12);
-                rngstepn!(3, 33);
-            }
-        }
-
-        self.a = a;
-        self.b = b;
-        self.cnt = RAND_SIZE_64;
-    }
-}
-
-// Cannot be derived because [u32; 256] does not implement Clone
-impl Clone for Isaac64Rng {
-    fn clone(&self) -> Isaac64Rng {
-        *self
-    }
-}
-
-impl Rng for Isaac64Rng {
-    #[inline]
-    fn next_u32(&mut self) -> u32 {
-        self.next_u64() as u32
-    }
-
-    #[inline]
-    fn next_u64(&mut self) -> u64 {
-        if self.cnt == 0 {
-            // make some more numbers
-            self.isaac64();
-        }
-        self.cnt -= 1;
-
-        // See corresponding location in IsaacRng.next_u32 for
-        // explanation.
-        debug_assert!(self.cnt < RAND_SIZE_64);
-        self.rsl[(self.cnt % RAND_SIZE_64) as usize].0
-    }
-}
-
-impl FromRng for Isaac64Rng {
-    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Isaac64Rng {
-        let mut ret = EMPTY_64;
-        unsafe {
-            let ptr = ret.rsl.as_mut_ptr() as *mut u8;
-
-            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE_64 * 8);
-            other.fill_bytes(slice);
-        }
-        ret.cnt = 0;
-        ret.a = w(0);
-        ret.b = w(0);
-        ret.c = w(0);
-
-        ret.init(true);
-        return ret;
-    }
-}
-
-impl<'a> SeedableRng<&'a [u64]> for Isaac64Rng {
-    fn reseed(&mut self, seed: &'a [u64]) {
-        // make the seed into [seed[0], seed[1], ..., seed[seed.len()
-        // - 1], 0, 0, ...], to fill rng.rsl.
-        let seed_iter = seed.iter().map(|&x| x).chain(repeat(0u64));
-
-        for (rsl_elem, seed_elem) in self.rsl.iter_mut().zip(seed_iter) {
-            *rsl_elem = w(seed_elem);
-        }
-        self.cnt = 0;
-        self.a = w(0);
-        self.b = w(0);
-        self.c = w(0);
-
-        self.init(true);
-    }
-
-    /// Create an ISAAC random number generator with a seed. This can
-    /// be any length, although the maximum number of elements used is
-    /// 256 and any more will be silently ignored. A generator
-    /// constructed with a given seed will generate the same sequence
-    /// of values as all other generators constructed with that seed.
-    fn from_seed(seed: &'a [u64]) -> Isaac64Rng {
-        let mut rng = EMPTY_64;
-        rng.reseed(seed);
-        rng
-    }
-}
-
-impl fmt::Debug for Isaac64Rng {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Isaac64Rng {{}}")
-    }
-}
-
 #[cfg(test)]
 mod test {
     use {Rng, SeedableRng, iter};
     use distributions::ascii_word_char;
-    use super::{IsaacRng, Isaac64Rng};
+    use super::IsaacRng;
 
     #[test]
     fn test_rng_32_rand_seeded() {
         let s = iter(&mut ::test::rng()).map(|rng| rng.next_u32()).take(256).collect::<Vec<u32>>();
         let mut ra: IsaacRng = SeedableRng::from_seed(&s[..]);
         let mut rb: IsaacRng = SeedableRng::from_seed(&s[..]);
-        assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
-                                iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
-    }
-    #[test]
-    fn test_rng_64_rand_seeded() {
-        let s = iter(&mut ::test::rng()).map(|rng| rng.next_u64()).take(256).collect::<Vec<u64>>();
-        let mut ra: Isaac64Rng = SeedableRng::from_seed(&s[..]);
-        let mut rb: Isaac64Rng = SeedableRng::from_seed(&s[..]);
         assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
                                 iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
     }
@@ -556,30 +292,11 @@ mod test {
         assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
                                 iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
     }
-    #[test]
-    fn test_rng_64_seeded() {
-        let seed: &[_] = &[1, 23, 456, 7890, 12345];
-        let mut ra: Isaac64Rng = SeedableRng::from_seed(seed);
-        let mut rb: Isaac64Rng = SeedableRng::from_seed(seed);
-        assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
-                                iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
-    }
 
     #[test]
     fn test_rng_32_reseed() {
         let s = iter(&mut ::test::rng()).map(|rng| rng.next_u32()).take(256).collect::<Vec<u32>>();
         let mut r: IsaacRng = SeedableRng::from_seed(&s[..]);
-        let string1: String = iter(&mut r).map(|rng| ascii_word_char(rng)).take(100).collect();
-
-        r.reseed(&s[..]);
-
-        let string2: String = iter(&mut r).map(|rng| ascii_word_char(rng)).take(100).collect();
-        assert_eq!(string1, string2);
-    }
-    #[test]
-    fn test_rng_64_reseed() {
-        let s = iter(&mut ::test::rng()).map(|rng| rng.next_u64()).take(256).collect::<Vec<u64>>();
-        let mut r: Isaac64Rng = SeedableRng::from_seed(&s[..]);
         let string1: String = iter(&mut r).map(|rng| ascii_word_char(rng)).take(100).collect();
 
         r.reseed(&s[..]);
@@ -608,38 +325,14 @@ mod test {
                    vec!(3676831399, 3183332890, 2834741178, 3854698763, 2717568474,
                         1576568959, 3507990155, 179069555, 141456972, 2478885421));
     }
-    #[test]
-    fn test_rng_64_true_values() {
-        let seed: &[_] = &[1, 23, 456, 7890, 12345];
-        let mut ra: Isaac64Rng = SeedableRng::from_seed(seed);
-        // Regression test that isaac is actually using the above vector
-        let v = (0..10).map(|_| ra.next_u64()).collect::<Vec<_>>();
-        assert_eq!(v,
-                   vec!(547121783600835980, 14377643087320773276, 17351601304698403469,
-                        1238879483818134882, 11952566807690396487, 13970131091560099343,
-                        4469761996653280935, 15552757044682284409, 6860251611068737823,
-                        13722198873481261842));
-
-        let seed: &[_] = &[12345, 67890, 54321, 9876];
-        let mut rb: Isaac64Rng = SeedableRng::from_seed(seed);
-        // skip forward to the 10000th number
-        for _ in 0..10000 { rb.next_u64(); }
-
-        let v = (0..10).map(|_| rb.next_u64()).collect::<Vec<_>>();
-        assert_eq!(v,
-                   vec!(18143823860592706164, 8491801882678285927, 2699425367717515619,
-                        17196852593171130876, 2606123525235546165, 15790932315217671084,
-                        596345674630742204, 9947027391921273664, 11788097613744130851,
-                        10391409374914919106));
-    }
 
     #[test]
     fn test_rng_clone() {
         let seed: &[_] = &[1, 23, 456, 7890, 12345];
-        let mut rng: Isaac64Rng = SeedableRng::from_seed(seed);
+        let mut rng: IsaacRng = SeedableRng::from_seed(seed);
         let mut clone = rng.clone();
         for _ in 0..16 {
-            assert_eq!(rng.next_u64(), clone.next_u64());
+            assert_eq!(rng.next_u32(), clone.next_u32());
         }
     }
 }

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -23,15 +23,70 @@ type w32 = w<u32>;
 const RAND_SIZE_LEN: usize = 8;
 const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 
-/// A random number generator that uses the ISAAC algorithm[1].
+/// A random number generator that uses the ISAAC algorithm.
 ///
-/// The ISAAC algorithm is generally accepted as suitable for
-/// cryptographic purposes, but this implementation has not be
-/// verified as such. Prefer a generator like `OsRng` that defers to
-/// the operating system for cases that need high security.
+/// ISAAC stands for "Indirection, Shift, Accumulate, Add, and Count" which are
+/// the principal bitwise operations employed. It is the most advanced of a
+/// series of array based random number generator designed by Robert Jenkins
+/// in 1996[1][2].
 ///
-/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
-/// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
+/// Although ISAAC is designed to be cryptographically secure, its design is not
+/// founded in cryptographic theory. Therefore it is _not recommended for_
+/// cryptographic purposes. It is however one of the strongest non-cryptograpic
+/// RNGs, and that while still being reasonably fast.
+///
+/// Where fast random numbers are needed which should still be secure, but where
+/// speed is more important than absolute (cryptographic) security (e.g. to
+/// initialise hashes in the std library), a generator like ISAAC may be a good
+/// choice.
+///
+/// In 2006 an improvement to ISAAC was suggested by Jean-Philippe Aumasson,
+/// named ISAAC+[3]. But because the specification is not complete, there is no
+/// good implementation, and because the suggested bias may not exist, it is not
+/// implemented here.
+///
+/// ## Overview of the ISAAC algorithm:
+/// (in pseudo-code)
+///
+/// ```text
+/// Input: a, b, c, s[256] // state
+/// Output: r[256]         // results
+///
+/// mix(a,i) = a ^ a << 13   if i = 0 mod 4
+///            a ^ a >>  6   if i = 1 mod 4
+///            a ^ a <<  2   if i = 2 mod 4
+///            a ^ a >> 16   if i = 3 mod 4
+///
+/// c = c + 1
+/// b = b + c
+///
+/// for i in 0..256 {
+///     x = s_[i]
+///     a = f(a,i) + s[i+128 mod 256]
+///     y = a + b + s[x>>2 mod 256]
+///     s[i] = y
+///     b = x + s[y>>10 mod 256]
+///     r[i] = b
+/// }
+/// ```
+///
+/// Numbers are generated in blocks of 256. This means the function above only
+/// runs once every 256 times you ask for a next random number. In all other
+/// circumstances the last element of the results array is returned.
+///
+/// ISAAC therefore needs a lot of memory, relative to other non-vrypto RNGs.
+/// 2 * 256 * 4 = 2 kb to hold the state and results.
+///
+/// ## References
+/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number generator*]
+///      (http://burtleburtle.net/bob/rand/isaacafa.html)
+///
+/// [2]: Bob Jenkins, [*ISAAC and RC4*]
+///      (http://burtleburtle.net/bob/rand/isaac.html)
+///
+/// [3]: Jean-Philippe Aumasson, [*On the pseudo-random generator ISAAC*]
+///      (http://eprint.iacr.org/2006/438)
+
 #[derive(Copy)]
 pub struct IsaacRng {
     rsl: [w32; RAND_SIZE],
@@ -121,6 +176,20 @@ impl IsaacRng {
     }
 
     /// Refills the output buffer (`self.rsl`)
+    /// See also the pseudocode desciption of the algorithm at the top of this
+    /// file.
+    ///
+    /// Optimisations used (similar to the reference implementation):
+    /// - The loop is unrolled 4 times, once for every constant of mix().
+    /// - The contents of the main loop are moved to a function `rngstep`, to
+    ///   reduce code duplication.
+    /// - We use local variables for a and b, which helps with optimisations.
+    /// - We split the main loop in two, one that operates over 0..128 and one
+    ///   over 128..256. This way we can optimise out the addition and modulus
+    ///   from `s[i+128 mod 256]`.
+    /// - We maintain one index `i` and add `m` or `m2` as base (m2 for the
+    ///   `s[i+128 mod 256]`), relying on the optimizer to turn it into pointer
+    ///   arithmetic.
     fn isaac(&mut self) {
         self.c += w(1);
         // abbreviations

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -1,0 +1,343 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The ISAAC random number generator.
+
+#![allow(non_camel_case_types)]
+
+use core::slice;
+use core::iter::repeat;
+use core::num::Wrapping as w;
+use core::fmt;
+
+use {Rng, FromRng, SeedableRng};
+
+#[allow(bad_style)]
+type w64 = w<u64>;
+
+const RAND_SIZE_64_LEN: usize = 8;
+const RAND_SIZE_64: usize = 1 << RAND_SIZE_64_LEN;
+
+/// A random number generator that uses ISAAC-64[1], the 64-bit
+/// variant of the ISAAC algorithm.
+///
+/// The ISAAC algorithm is generally accepted as suitable for
+/// cryptographic purposes, but this implementation has not be
+/// verified as such. Prefer a generator like `OsRng` that defers to
+/// the operating system for cases that need high security.
+///
+/// [1]: Bob Jenkins, [*ISAAC: A fast cryptographic random number
+/// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
+#[derive(Copy)]
+pub struct Isaac64Rng {
+    cnt: usize,
+    rsl: [w64; RAND_SIZE_64],
+    mem: [w64; RAND_SIZE_64],
+    a: w64,
+    b: w64,
+    c: w64,
+}
+
+static EMPTY_64: Isaac64Rng = Isaac64Rng {
+    cnt: 0,
+    rsl: [w(0); RAND_SIZE_64],
+    mem: [w(0); RAND_SIZE_64],
+    a: w(0), b: w(0), c: w(0),
+};
+
+impl Isaac64Rng {
+    /// Create a 64-bit ISAAC random number generator using the
+    /// default fixed seed.
+    pub fn new_unseeded() -> Isaac64Rng {
+        let mut rng = EMPTY_64;
+        rng.init(false);
+        rng
+    }
+
+    /// Initialises `self`. If `use_rsl` is true, then use the current value
+    /// of `rsl` as a seed, otherwise construct one algorithmically (not
+    /// randomly).
+    fn init(&mut self, use_rsl: bool) {
+        macro_rules! init {
+            ($var:ident) => (
+                let mut $var = w(0x9e3779b97f4a7c13);
+            )
+        }
+        init!(a); init!(b); init!(c); init!(d);
+        init!(e); init!(f); init!(g); init!(h);
+
+        macro_rules! mix {
+            () => {{
+                a=a-e; f=f^(h>>9);  h=h+a;
+                b=b-f; g=g^(a<<9);  a=a+b;
+                c=c-g; h=h^(b>>23); b=b+c;
+                d=d-h; a=a^(c<<15); c=c+d;
+                e=e-a; b=b^(d>>14); d=d+e;
+                f=f-b; c=c^(e<<20); e=e+f;
+                g=g-c; d=d^(f>>17); f=f+g;
+                h=h-d; e=e^(g<<14); g=g+h;
+            }}
+        }
+
+        for _ in 0..4 {
+            mix!();
+        }
+
+        if use_rsl {
+            macro_rules! memloop {
+                ($arr:expr) => {{
+                    for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
+                        a=a+$arr[i  ]; b=b+$arr[i+1];
+                        c=c+$arr[i+2]; d=d+$arr[i+3];
+                        e=e+$arr[i+4]; f=f+$arr[i+5];
+                        g=g+$arr[i+6]; h=h+$arr[i+7];
+                        mix!();
+                        self.mem[i  ]=a; self.mem[i+1]=b;
+                        self.mem[i+2]=c; self.mem[i+3]=d;
+                        self.mem[i+4]=e; self.mem[i+5]=f;
+                        self.mem[i+6]=g; self.mem[i+7]=h;
+                    }
+                }}
+            }
+
+            memloop!(self.rsl);
+            memloop!(self.mem);
+        } else {
+            for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
+                mix!();
+                self.mem[i  ]=a; self.mem[i+1]=b;
+                self.mem[i+2]=c; self.mem[i+3]=d;
+                self.mem[i+4]=e; self.mem[i+5]=f;
+                self.mem[i+6]=g; self.mem[i+7]=h;
+            }
+        }
+
+        self.isaac64();
+    }
+
+    /// Refills the output buffer (`self.rsl`)
+    fn isaac64(&mut self) {
+        self.c = self.c + w(1);
+        // abbreviations
+        let mut a = self.a;
+        let mut b = self.b + self.c;
+        const MIDPOINT: usize =  RAND_SIZE_64 / 2;
+        const MP_VEC: [(usize, usize); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
+        macro_rules! ind {
+            ($x:expr) => {
+                *self.mem.get_unchecked((($x >> 3usize).0 as usize) & (RAND_SIZE_64 - 1))
+            }
+        }
+
+        for &(mr_offset, m2_offset) in MP_VEC.iter() {
+            for base in (0..MIDPOINT / 4).map(|i| i * 4) {
+
+                macro_rules! rngstepp {
+                    ($j:expr, $shift:expr) => {{
+                        let base = base + $j;
+                        let mix = a ^ (a << $shift);
+                        let mix = if $j == 0 {!mix} else {mix};
+
+                        unsafe {
+                            let x = *self.mem.get_unchecked(base + mr_offset);
+                            a = mix + *self.mem.get_unchecked(base + m2_offset);
+                            let y = ind!(x) + a + b;
+                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
+
+                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
+                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
+                        }
+                    }}
+                }
+
+                macro_rules! rngstepn {
+                    ($j:expr, $shift:expr) => {{
+                        let base = base + $j;
+                        let mix = a ^ (a >> $shift);
+                        let mix = if $j == 0 {!mix} else {mix};
+
+                        unsafe {
+                            let x = *self.mem.get_unchecked(base + mr_offset);
+                            a = mix + *self.mem.get_unchecked(base + m2_offset);
+                            let y = ind!(x) + a + b;
+                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
+
+                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
+                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
+                        }
+                    }}
+                }
+
+                rngstepp!(0, 21);
+                rngstepn!(1, 5);
+                rngstepp!(2, 12);
+                rngstepn!(3, 33);
+            }
+        }
+
+        self.a = a;
+        self.b = b;
+        self.cnt = RAND_SIZE_64;
+    }
+}
+
+// Cannot be derived because [u32; 256] does not implement Clone
+impl Clone for Isaac64Rng {
+    fn clone(&self) -> Isaac64Rng {
+        *self
+    }
+}
+
+impl Rng for Isaac64Rng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.next_u64() as u32
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        if self.cnt == 0 {
+            // make some more numbers
+            self.isaac64();
+        }
+        self.cnt -= 1;
+
+        // See corresponding location in IsaacRng.next_u32 for
+        // explanation.
+        debug_assert!(self.cnt < RAND_SIZE_64);
+        self.rsl[(self.cnt % RAND_SIZE_64) as usize].0
+    }
+}
+
+impl FromRng for Isaac64Rng {
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Isaac64Rng {
+        let mut ret = EMPTY_64;
+        unsafe {
+            let ptr = ret.rsl.as_mut_ptr() as *mut u8;
+
+            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE_64 * 8);
+            other.fill_bytes(slice);
+        }
+        ret.cnt = 0;
+        ret.a = w(0);
+        ret.b = w(0);
+        ret.c = w(0);
+
+        ret.init(true);
+        return ret;
+    }
+}
+
+impl<'a> SeedableRng<&'a [u64]> for Isaac64Rng {
+    fn reseed(&mut self, seed: &'a [u64]) {
+        // make the seed into [seed[0], seed[1], ..., seed[seed.len()
+        // - 1], 0, 0, ...], to fill rng.rsl.
+        let seed_iter = seed.iter().map(|&x| x).chain(repeat(0u64));
+
+        for (rsl_elem, seed_elem) in self.rsl.iter_mut().zip(seed_iter) {
+            *rsl_elem = w(seed_elem);
+        }
+        self.cnt = 0;
+        self.a = w(0);
+        self.b = w(0);
+        self.c = w(0);
+
+        self.init(true);
+    }
+
+    /// Create an ISAAC random number generator with a seed. This can
+    /// be any length, although the maximum number of elements used is
+    /// 256 and any more will be silently ignored. A generator
+    /// constructed with a given seed will generate the same sequence
+    /// of values as all other generators constructed with that seed.
+    fn from_seed(seed: &'a [u64]) -> Isaac64Rng {
+        let mut rng = EMPTY_64;
+        rng.reseed(seed);
+        rng
+    }
+}
+
+impl fmt::Debug for Isaac64Rng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Isaac64Rng {{}}")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {Rng, SeedableRng, iter};
+    use distributions::ascii_word_char;
+    use super::Isaac64Rng;
+
+    #[test]
+    fn test_rng_64_rand_seeded() {
+        let s = iter(&mut ::test::rng()).map(|rng| rng.next_u64()).take(256).collect::<Vec<u64>>();
+        let mut ra: Isaac64Rng = SeedableRng::from_seed(&s[..]);
+        let mut rb: Isaac64Rng = SeedableRng::from_seed(&s[..]);
+        assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
+                                iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
+    }
+
+    #[test]
+    fn test_rng_64_seeded() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut ra: Isaac64Rng = SeedableRng::from_seed(seed);
+        let mut rb: Isaac64Rng = SeedableRng::from_seed(seed);
+        assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
+                                iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
+    }
+
+    #[test]
+    fn test_rng_64_reseed() {
+        let s = iter(&mut ::test::rng()).map(|rng| rng.next_u64()).take(256).collect::<Vec<u64>>();
+        let mut r: Isaac64Rng = SeedableRng::from_seed(&s[..]);
+        let string1: String = iter(&mut r).map(|rng| ascii_word_char(rng)).take(100).collect();
+
+        r.reseed(&s[..]);
+
+        let string2: String = iter(&mut r).map(|rng| ascii_word_char(rng)).take(100).collect();
+        assert_eq!(string1, string2);
+    }
+
+    #[test]
+    fn test_rng_64_true_values() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut ra: Isaac64Rng = SeedableRng::from_seed(seed);
+        // Regression test that isaac is actually using the above vector
+        let v = (0..10).map(|_| ra.next_u64()).collect::<Vec<_>>();
+        assert_eq!(v,
+                   vec!(547121783600835980, 14377643087320773276, 17351601304698403469,
+                        1238879483818134882, 11952566807690396487, 13970131091560099343,
+                        4469761996653280935, 15552757044682284409, 6860251611068737823,
+                        13722198873481261842));
+
+        let seed: &[_] = &[12345, 67890, 54321, 9876];
+        let mut rb: Isaac64Rng = SeedableRng::from_seed(seed);
+        // skip forward to the 10000th number
+        for _ in 0..10000 { rb.next_u64(); }
+
+        let v = (0..10).map(|_| rb.next_u64()).collect::<Vec<_>>();
+        assert_eq!(v,
+                   vec!(18143823860592706164, 8491801882678285927, 2699425367717515619,
+                        17196852593171130876, 2606123525235546165, 15790932315217671084,
+                        596345674630742204, 9947027391921273664, 11788097613744130851,
+                        10391409374914919106));
+    }
+
+    #[test]
+    fn test_rng_clone() {
+        let seed: &[_] = &[1, 23, 456, 7890, 12345];
+        let mut rng: Isaac64Rng = SeedableRng::from_seed(seed);
+        let mut clone = rng.clone();
+        for _ in 0..16 {
+            assert_eq!(rng.next_u64(), clone.next_u64());
+        }
+    }
+}

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -10,8 +10,6 @@
 
 //! The ISAAC random number generator.
 
-#![allow(non_camel_case_types)]
-
 use core::slice;
 use core::iter::repeat;
 use core::num::Wrapping as w;
@@ -19,11 +17,11 @@ use core::fmt;
 
 use {Rng, FromRng, SeedableRng};
 
-#[allow(bad_style)]
+#[allow(non_camel_case_types)]
 type w64 = w<u64>;
 
-const RAND_SIZE_64_LEN: usize = 8;
-const RAND_SIZE_64: usize = 1 << RAND_SIZE_64_LEN;
+const RAND_SIZE_LEN: usize = 8;
+const RAND_SIZE: usize = 1 << RAND_SIZE_LEN;
 
 /// A random number generator that uses ISAAC-64[1], the 64-bit
 /// variant of the ISAAC algorithm.
@@ -37,18 +35,18 @@ const RAND_SIZE_64: usize = 1 << RAND_SIZE_64_LEN;
 /// generator*](http://www.burtleburtle.net/bob/rand/isaacafa.html)
 #[derive(Copy)]
 pub struct Isaac64Rng {
-    cnt: usize,
-    rsl: [w64; RAND_SIZE_64],
-    mem: [w64; RAND_SIZE_64],
+    rsl: [w64; RAND_SIZE],
+    mem: [w64; RAND_SIZE],
     a: w64,
     b: w64,
     c: w64,
+    cnt: u32,
 }
 
 static EMPTY_64: Isaac64Rng = Isaac64Rng {
     cnt: 0,
-    rsl: [w(0); RAND_SIZE_64],
-    mem: [w(0); RAND_SIZE_64],
+    rsl: [w(0); RAND_SIZE],
+    mem: [w(0); RAND_SIZE],
     a: w(0), b: w(0), c: w(0),
 };
 
@@ -65,24 +63,25 @@ impl Isaac64Rng {
     /// of `rsl` as a seed, otherwise construct one algorithmically (not
     /// randomly).
     fn init(&mut self, use_rsl: bool) {
-        macro_rules! init {
-            ($var:ident) => (
-                let mut $var = w(0x9e3779b97f4a7c13);
-            )
-        }
-        init!(a); init!(b); init!(c); init!(d);
-        init!(e); init!(f); init!(g); init!(h);
+        let mut a = w(0x9e3779b97f4a7c13); // golden ratio
+        let mut b = a;
+        let mut c = a;
+        let mut d = a;
+        let mut e = a;
+        let mut f = a;
+        let mut g = a;
+        let mut h = a;
 
         macro_rules! mix {
             () => {{
-                a=a-e; f=f^(h>>9);  h=h+a;
-                b=b-f; g=g^(a<<9);  a=a+b;
-                c=c-g; h=h^(b>>23); b=b+c;
-                d=d-h; a=a^(c<<15); c=c+d;
-                e=e-a; b=b^(d>>14); d=d+e;
-                f=f-b; c=c^(e<<20); e=e+f;
-                g=g-c; d=d^(f>>17); f=f+g;
-                h=h-d; e=e^(g<<14); g=g+h;
+                a -= e; f ^= h >> 9;  h += a;
+                b -= f; g ^= a << 9;  a += b;
+                c -= g; h ^= b >> 23; b += c;
+                d -= h; a ^= c << 15; c += d;
+                e -= a; b ^= d >> 14; d += e;
+                f -= b; c ^= e << 20; e += f;
+                g -= c; d ^= f >> 17; f += g;
+                h -= d; e ^= g << 14; g += h;
             }}
         }
 
@@ -93,16 +92,16 @@ impl Isaac64Rng {
         if use_rsl {
             macro_rules! memloop {
                 ($arr:expr) => {{
-                    for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
-                        a=a+$arr[i  ]; b=b+$arr[i+1];
-                        c=c+$arr[i+2]; d=d+$arr[i+3];
-                        e=e+$arr[i+4]; f=f+$arr[i+5];
-                        g=g+$arr[i+6]; h=h+$arr[i+7];
+                    for i in (0..RAND_SIZE/8).map(|i| i * 8) {
+                        a += $arr[i  ]; b += $arr[i+1];
+                        c += $arr[i+2]; d += $arr[i+3];
+                        e += $arr[i+4]; f += $arr[i+5];
+                        g += $arr[i+6]; h += $arr[i+7];
                         mix!();
-                        self.mem[i  ]=a; self.mem[i+1]=b;
-                        self.mem[i+2]=c; self.mem[i+3]=d;
-                        self.mem[i+4]=e; self.mem[i+5]=f;
-                        self.mem[i+6]=g; self.mem[i+7]=h;
+                        self.mem[i  ] = a; self.mem[i+1] = b;
+                        self.mem[i+2] = c; self.mem[i+3] = d;
+                        self.mem[i+4] = e; self.mem[i+5] = f;
+                        self.mem[i+6] = g; self.mem[i+7] = h;
                     }
                 }}
             }
@@ -110,12 +109,12 @@ impl Isaac64Rng {
             memloop!(self.rsl);
             memloop!(self.mem);
         } else {
-            for i in (0..RAND_SIZE_64 / 8).map(|i| i * 8) {
+            for i in (0..RAND_SIZE/8).map(|i| i * 8) {
                 mix!();
-                self.mem[i  ]=a; self.mem[i+1]=b;
-                self.mem[i+2]=c; self.mem[i+3]=d;
-                self.mem[i+4]=e; self.mem[i+5]=f;
-                self.mem[i+6]=g; self.mem[i+7]=h;
+                self.mem[i  ] = a; self.mem[i+1] = b;
+                self.mem[i+2] = c; self.mem[i+3] = d;
+                self.mem[i+4] = e; self.mem[i+5] = f;
+                self.mem[i+6] = g; self.mem[i+7] = h;
             }
         }
 
@@ -124,67 +123,55 @@ impl Isaac64Rng {
 
     /// Refills the output buffer (`self.rsl`)
     fn isaac64(&mut self) {
-        self.c = self.c + w(1);
+        self.c += w(1);
         // abbreviations
         let mut a = self.a;
         let mut b = self.b + self.c;
-        const MIDPOINT: usize =  RAND_SIZE_64 / 2;
-        const MP_VEC: [(usize, usize); 2] = [(0,MIDPOINT), (MIDPOINT, 0)];
-        macro_rules! ind {
-            ($x:expr) => {
-                *self.mem.get_unchecked((($x >> 3usize).0 as usize) & (RAND_SIZE_64 - 1))
-            }
+        const MIDPOINT: usize = RAND_SIZE / 2;
+
+        #[inline(always)]
+        fn ind(mem:&[w64; RAND_SIZE], v: w64, amount: usize) -> w64 {
+            let index = (v >> amount).0 as usize % RAND_SIZE;
+            mem[index]
         }
 
-        for &(mr_offset, m2_offset) in MP_VEC.iter() {
-            for base in (0..MIDPOINT / 4).map(|i| i * 4) {
+        #[inline(always)]
+        fn rngstep(ctx: &mut Isaac64Rng,
+                   mix: w64,
+                   a: &mut w64,
+                   b: &mut w64,
+                   base: usize,
+                   m: usize,
+                   m2: usize) {
+            let x = ctx.mem[base + m];
+            *a = mix + ctx.mem[base + m2];
+            let y = *a + *b + ind(&ctx.mem, x, 3);
+            ctx.mem[base + m] = y;
+            *b = x + ind(&ctx.mem, y, 3 + RAND_SIZE_LEN);
+            ctx.rsl[base + m] = *b;
+        }
 
-                macro_rules! rngstepp {
-                    ($j:expr, $shift:expr) => {{
-                        let base = base + $j;
-                        let mix = a ^ (a << $shift);
-                        let mix = if $j == 0 {!mix} else {mix};
+        let mut m = 0;
+        let mut m2 = MIDPOINT;
+        for i in (0..MIDPOINT/4).map(|i| i * 4) {
+            rngstep(self, !(a ^ (a << 21)), &mut a, &mut b, i + 0, m, m2);
+            rngstep(self,   a ^ (a >> 5 ),  &mut a, &mut b, i + 1, m, m2);
+            rngstep(self,   a ^ (a << 12),  &mut a, &mut b, i + 2, m, m2);
+            rngstep(self,   a ^ (a >> 33),  &mut a, &mut b, i + 3, m, m2);
+        }
 
-                        unsafe {
-                            let x = *self.mem.get_unchecked(base + mr_offset);
-                            a = mix + *self.mem.get_unchecked(base + m2_offset);
-                            let y = ind!(x) + a + b;
-                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
-
-                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
-                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
-                        }
-                    }}
-                }
-
-                macro_rules! rngstepn {
-                    ($j:expr, $shift:expr) => {{
-                        let base = base + $j;
-                        let mix = a ^ (a >> $shift);
-                        let mix = if $j == 0 {!mix} else {mix};
-
-                        unsafe {
-                            let x = *self.mem.get_unchecked(base + mr_offset);
-                            a = mix + *self.mem.get_unchecked(base + m2_offset);
-                            let y = ind!(x) + a + b;
-                            *self.mem.get_unchecked_mut(base + mr_offset) = y;
-
-                            b = ind!(y >> RAND_SIZE_64_LEN) + x;
-                            *self.rsl.get_unchecked_mut(base + mr_offset) = b;
-                        }
-                    }}
-                }
-
-                rngstepp!(0, 21);
-                rngstepn!(1, 5);
-                rngstepp!(2, 12);
-                rngstepn!(3, 33);
-            }
+        m = MIDPOINT;
+        m2 = 0;
+        for i in (0..MIDPOINT/4).map(|i| i * 4) {
+            rngstep(self, !(a ^ (a << 21)), &mut a, &mut b, i + 0, m, m2);
+            rngstep(self,   a ^ (a >> 5 ),  &mut a, &mut b, i + 1, m, m2);
+            rngstep(self,   a ^ (a << 12),  &mut a, &mut b, i + 2, m, m2);
+            rngstep(self,   a ^ (a >> 33),  &mut a, &mut b, i + 3, m, m2);
         }
 
         self.a = a;
         self.b = b;
-        self.cnt = RAND_SIZE_64;
+        self.cnt = RAND_SIZE as u32;
     }
 }
 
@@ -209,10 +196,18 @@ impl Rng for Isaac64Rng {
         }
         self.cnt -= 1;
 
-        // See corresponding location in IsaacRng.next_u32 for
-        // explanation.
-        debug_assert!(self.cnt < RAND_SIZE_64);
-        self.rsl[(self.cnt % RAND_SIZE_64) as usize].0
+        // self.cnt is at most RAND_SIZE, but that is before the
+        // subtraction above. We want to index without bounds
+        // checking, but this could lead to incorrect code if someone
+        // misrefactors, so we check, sometimes.
+        //
+        // (Changes here should be reflected in IsaacRng.next_u32.)
+        debug_assert!((self.cnt as usize) < RAND_SIZE);
+
+        // (the % is cheaply telling the optimiser that we're always
+        // in bounds, without unsafe. NB. this is a power of two, so
+        // it optimises to a bitwise mask).
+        self.rsl[self.cnt as usize % RAND_SIZE].0
     }
 }
 
@@ -222,7 +217,7 @@ impl FromRng for Isaac64Rng {
         unsafe {
             let ptr = ret.rsl.as_mut_ptr() as *mut u8;
 
-            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE_64 * 8);
+            let slice = slice::from_raw_parts_mut(ptr, RAND_SIZE * 8);
             other.fill_bytes(slice);
         }
         ret.cnt = 0;

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -10,8 +10,105 @@
 
 //! The ISAAC random number generator.
 
-/// Select 32- or 64-bit variant dependent on pointer size.
+use core::fmt;
+use {Rng, FromRng, SeedableRng};
+
 #[cfg(target_pointer_width = "32")]
-pub use prng::isaac::IsaacRng as IsaacWordRng;
+#[derive(Copy)]
+/// A random number generator that uses the ISAAC or ISAAC-64 algorithm,
+/// depending on the pointer size of the target architecture.
+///
+/// In general a random number generator that internally uses the word size of
+/// the target architecture is faster than one that doesn't. Choosing
+/// `IsaacWordRng` is therefore often a better choice than `IsaacRng` or
+/// `Isaac64Rng`. The others can be a good choice if reproducability across
+/// different architectures is desired. `IsaacRng` can also be a better choice
+/// if memory usage is an issue, as it uses 2kb of state instead of the 4kb
+/// `Isaac64Rng` uses.
+///
+/// See for an explanation of the algorithm `IsaacRng` and `Isaac64Rng`.
+pub struct IsaacWordRng(super::isaac::IsaacRng);
+
 #[cfg(target_pointer_width = "64")]
-pub use prng::isaac64::Isaac64Rng as IsaacWordRng;
+#[derive(Copy)]
+/// A random number generator that uses the ISAAC or ISAAC-64 algorithm,
+/// depending on the pointer size of the target architecture.
+///
+/// In general a random number generator that internally uses the word size of
+/// the target architecture is faster than one that doesn't. Choosing
+/// `IsaacWordRng` is therefore often a better choice than `IsaacRng` or
+/// `Isaac64Rng`. The others can be a good choice if reproducability across
+/// different architectures is desired. `IsaacRng` can also be a better choice
+/// if memory usage is an issue, as it uses 2kb of state instead of the 4kb
+/// `Isaac64Rng` uses.
+///
+/// See for an explanation of the algorithm `IsaacRng` and `Isaac64Rng`.
+pub struct IsaacWordRng(super::isaac64::Isaac64Rng);
+
+impl Clone for IsaacWordRng {
+    fn clone(&self) -> IsaacWordRng {
+        *self
+    }
+}
+
+impl Rng for IsaacWordRng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+}
+
+impl FromRng for IsaacWordRng {
+    #[cfg(target_pointer_width = "32")]
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> IsaacWordRng {
+        IsaacWordRng(super::isaac::IsaacRng::from_rng(other))
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> IsaacWordRng {
+        IsaacWordRng(super::isaac64::Isaac64Rng::from_rng(other))
+    }
+}
+
+#[cfg(target_pointer_width = "32")]
+impl<'a> SeedableRng<&'a [u32]> for IsaacWordRng {
+    fn reseed(&mut self, seed: &'a [u32]) {
+        self.0.reseed(seed)
+    }
+
+    /// Create an ISAAC random number generator with a seed. This can
+    /// be any length, although the maximum number of elements used is
+    /// 256 and any more will be silently ignored. A generator
+    /// constructed with a given seed will generate the same sequence
+    /// of values as all other generators constructed with that seed.
+    fn from_seed(seed: &'a [u32]) -> IsaacWordRng {
+        IsaacWordRng(super::isaac::IsaacRng::from_seed(seed))
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl<'a> SeedableRng<&'a [u64]> for IsaacWordRng {
+    fn reseed(&mut self, seed: &'a [u64]) {
+        self.0.reseed(seed)
+    }
+
+    /// Create an ISAAC random number generator with a seed. This can
+    /// be any length, although the maximum number of elements used is
+    /// 256 and any more will be silently ignored. A generator
+    /// constructed with a given seed will generate the same sequence
+    /// of values as all other generators constructed with that seed.
+    fn from_seed(seed: &'a [u64]) -> IsaacWordRng {
+        IsaacWordRng(super::isaac64::Isaac64Rng::from_seed(seed))
+    }
+}
+
+impl fmt::Debug for IsaacWordRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "IsaacWordRng {{}}")
+    }
+}

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -1,0 +1,17 @@
+// Copyright 2013 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The ISAAC random number generator.
+
+/// Select 32- or 64-bit variant dependent on pointer size.
+#[cfg(target_pointer_width = "32")]
+pub use prng::isaac::IsaacRng as IsaacWordRng;
+#[cfg(target_pointer_width = "64")]
+pub use prng::isaac64::Isaac64Rng as IsaacWordRng;

--- a/src/prng/mod.rs
+++ b/src/prng/mod.rs
@@ -45,8 +45,12 @@
 
 mod chacha;
 mod isaac;
+mod isaac64;
+mod isaac_word;
 mod xorshift;
 
 pub use self::chacha::ChaChaRng;
-pub use self::isaac::{IsaacRng, Isaac64Rng, IsaacWordRng};
+pub use self::isaac::IsaacRng;
+pub use self::isaac64::Isaac64Rng;
+pub use self::isaac_word::IsaacWordRng;
 pub use self::xorshift::XorShiftRng;


### PR DESCRIPTION
You already said you are not likely to merge any ISAAC+ modifications. But I still give it a try, because most changes should be useful.

The first commit is just refactoring.
I have replaced some macro's by functions. This appearently made it possible to remove the unsafe indexing without a performance loss.

Over time the implementation of ISAAC and ISAAC-64 have diverged a bit, now they are as similar as possible (for easier comparison). IsaacRng now does 34% better in the benchmark :-)!

I have tested the code against the previous implementation, and the reference implementation.


The second commit does the modifications for ISAAC+. I can easily remove it if you want. But the problem is, that I do like to sometimes contribute to an existing project, but don't want to commit to a (small) library of myself.

The ISAAC+ algorithm is described in the paper _On the pseudo-random generator ISAAC_ by Jean-Philippe Aumasson. The specification is however not complete. The definition of f'(a,i) is missing. But the text says that in that step we should "perform rotations instead of shifts, so as to get more diffusion from the state bits". So f'(a,i) is f(a,i) with shifts replaced by rotations.

It mentions two other changes: in the `rngstep` function one addition should be replaced by a XOR. And there should be one extra XOR with `a`.

Finally the algorithm in the paper shows that in the `ind` function we should not do shifts, but rotations. But performing a rotation-right of 2 or 10 on an u32, and than only using the last 8 bits, is no different than a shift right. I suppose it makes it easier to describe the new algorithm as 'all shifts are replaced by rotations'.

I found one other (correct) implementation of ISAAC+: https://github.com/konovod/prngs/commit/749c33b6d54e083de2af2bde17268fc1171366c4