### PR TITLE
Error handling

### DIFF
--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -24,7 +24,7 @@
 //! TODO: should we add more implementations?
 
 use core::intrinsics::transmute;
-use {Rng, Error};
+use Rng;
 
 /// Implement `next_u64` via `next_u32`, little-endian order.
 pub fn next_u64_via_u32<R: Rng+?Sized>(rng: &mut R) -> u64 {
@@ -45,7 +45,7 @@ pub fn next_u128_via_u64<R: Rng+?Sized>(rng: &mut R) -> u128 {
     (y << 64) | x
 }
 
-macro_rules! try_fill_via {
+macro_rules! fill_bytes_via {
     ($rng:ident, $next_u:ident, $BYTES:expr, $dest:ident) => {{
         let mut left = $dest;
         while left.len() >= $BYTES {
@@ -63,24 +63,23 @@ macro_rules! try_fill_via {
             };
             left.copy_from_slice(&chunk[..n]);
         }
-        Ok(())
     }}
 }
 
-/// Implement `try_fill` via `next_u32`, little-endian order.
-pub fn try_fill_via_u32<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<(), Error> {
-    try_fill_via!(rng, next_u32, 4, dest)
+/// Implement `fill_bytes` via `next_u32`, little-endian order.
+pub fn fill_bytes_via_u32<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
+    fill_bytes_via!(rng, next_u32, 4, dest)
 }
 
-/// Implement `try_fill` via `next_u64`, little-endian order.
-pub fn try_fill_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<(), Error> {
-    try_fill_via!(rng, next_u64, 8, dest)
+/// Implement `fill_bytes` via `next_u64`, little-endian order.
+pub fn fill_bytes_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
+    fill_bytes_via!(rng, next_u64, 8, dest)
 }
 
-/// Implement `try_fill` via `next_u128`, little-endian order.
+/// Implement `fill_bytes` via `next_u128`, little-endian order.
 #[cfg(feature = "i128_support")]
-pub fn try_fill_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<(), Error> {
-    try_fill_via!(rng, next_u128, 16, dest)
+pub fn fill_bytes_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
+    fill_bytes_via!(rng, next_u128, 16, dest)
 }
 
 // TODO: implement tests for the above

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -24,7 +24,7 @@
 //! TODO: should we add more implementations?
 
 use core::intrinsics::transmute;
-use {Rng, Result};
+use {Rng, Error};
 
 /// Implement `next_u64` via `next_u32`, little-endian order.
 pub fn next_u64_via_u32<R: Rng+?Sized>(rng: &mut R) -> u64 {
@@ -68,18 +68,18 @@ macro_rules! try_fill_via {
 }
 
 /// Implement `try_fill` via `next_u32`, little-endian order.
-pub fn try_fill_via_u32<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<()> {
+pub fn try_fill_via_u32<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<(), Error> {
     try_fill_via!(rng, next_u32, 4, dest)
 }
 
 /// Implement `try_fill` via `next_u64`, little-endian order.
-pub fn try_fill_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<()> {
+pub fn try_fill_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<(), Error> {
     try_fill_via!(rng, next_u64, 8, dest)
 }
 
 /// Implement `try_fill` via `next_u128`, little-endian order.
 #[cfg(feature = "i128_support")]
-pub fn try_fill_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<()> {
+pub fn try_fill_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) -> Result<(), Error> {
     try_fill_via!(rng, next_u128, 16, dest)
 }
 

--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -82,4 +82,27 @@ pub fn fill_bytes_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
     fill_bytes_via!(rng, next_u128, 16, dest)
 }
 
+macro_rules! impl_uint_from_fill {
+    ($self:expr, $ty:ty, $N:expr) => ({
+        // Transmute and convert from LE (i.e. byte-swap on BE)
+        debug_assert!($N == ::core::mem::size_of::<$ty>());
+        let mut buf = [0u8; $N];
+        $self.fill_bytes(&mut buf);
+        unsafe{ *(buf.as_ptr() as *const $ty) }.to_le()
+    });
+}
+
+pub fn next_u32_via_fill<R: Rng+?Sized>(rng: &mut R) -> u32 {
+    impl_uint_from_fill!(rng, u32, 4)
+}
+
+pub fn next_u64_via_fill<R: Rng+?Sized>(rng: &mut R) -> u64 {
+    impl_uint_from_fill!(rng, u64, 8)
+}
+
+#[cfg(feature = "i128_support")]
+pub fn next_u128_via_fill<R: Rng+?Sized>(rng: &mut R) -> u128 {
+    impl_uint_from_fill!(rng, u128, 16)
+}
+
 // TODO: implement tests for the above

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -113,9 +113,7 @@ pub trait Rng {
     /// 1 is required. A different implementation might use `next_u32` and
     /// only consume 4 bytes; *however* any change affecting *reproducibility*
     /// of output must be considered a breaking change.
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        Ok(self.fill_bytes(dest))
-    }
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error>;
 }
 
 impl<'a, R: Rng+?Sized> Rng for &'a mut R {

--- a/rand_core/src/mock.rs
+++ b/rand_core/src/mock.rs
@@ -16,7 +16,7 @@
 //! Instead maybe this should be yet another crate? Or just leave it here?
 
 use core::num::Wrapping as w;
-use {Error, Rng, SeedableRng, impls};
+use {Rng, SeedableRng, impls};
 
 /// A simple implementation of `Rng`, purely for testing.
 /// Returns an arithmetic sequence (i.e. adds a constant each step).
@@ -57,8 +57,8 @@ impl Rng for MockAddRng<u32> {
         impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        impls::try_fill_via_u32(self, dest)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_u32(self, dest);
     }
 }
 
@@ -76,8 +76,8 @@ impl Rng for MockAddRng<u64> {
         impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        impls::try_fill_via_u32(self, dest)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        impls::fill_bytes_via_u64(self, dest);
     }
 }
 

--- a/rand_core/src/mock.rs
+++ b/rand_core/src/mock.rs
@@ -16,7 +16,7 @@
 //! Instead maybe this should be yet another crate? Or just leave it here?
 
 use core::num::Wrapping as w;
-use {Rng, SeedableRng, impls, Result};
+use {Error, Rng, SeedableRng, impls};
 
 /// A simple implementation of `Rng`, purely for testing.
 /// Returns an arithmetic sequence (i.e. adds a constant each step).
@@ -57,7 +57,7 @@ impl Rng for MockAddRng<u32> {
         impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         impls::try_fill_via_u32(self, dest)
     }
 }
@@ -76,7 +76,7 @@ impl Rng for MockAddRng<u64> {
         impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         impls::try_fill_via_u32(self, dest)
     }
 }

--- a/rand_core/src/mock.rs
+++ b/rand_core/src/mock.rs
@@ -16,7 +16,7 @@
 //! Instead maybe this should be yet another crate? Or just leave it here?
 
 use core::num::Wrapping as w;
-use {Rng, SeedableRng, impls};
+use {Rng, SeedableRng, Error, impls};
 
 /// A simple implementation of `Rng`, purely for testing.
 /// Returns an arithmetic sequence (i.e. adds a constant each step).
@@ -60,6 +60,10 @@ impl Rng for MockAddRng<u32> {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         impls::fill_bytes_via_u32(self, dest);
     }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
 }
 
 impl Rng for MockAddRng<u64> {
@@ -78,6 +82,10 @@ impl Rng for MockAddRng<u64> {
     
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         impls::fill_bytes_via_u64(self, dest);
+    }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ extern crate core;
 
 extern crate rand_core;
 
-pub use rand_core::{Rng, SeedFromRng, SeedableRng, Error, Result};
+pub use rand_core::{Rng, SeedFromRng, SeedableRng, Error, ErrorKind};
 
 #[cfg(feature="std")]
 pub use read::ReadRng;
@@ -293,12 +293,12 @@ mod thread_local;
 #[cfg(feature="std")]
 pub trait NewSeeded: Sized {
     /// Creates a new instance, automatically seeded via `OsRng`.
-    fn new() -> Result<Self>;
+    fn new() -> Result<Self, Error>;
 }
 
 #[cfg(feature="std")]
 impl<R: SeedFromRng> NewSeeded for R {
-    fn new() -> Result<Self> {
+    fn new() -> Result<Self, Error> {
         let mut r = OsRng::new()?;
         Self::from_rng(&mut r)
     }
@@ -416,13 +416,13 @@ impl Rng for StdRng {
     fn next_u128(&mut self) -> u128 {
         self.rng.next_u128()
     }
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.rng.try_fill(dest)
     }
 }
 
 impl SeedFromRng for StdRng {
-    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self> {
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self, Error> {
         IsaacWordRng::from_rng(other).map(|rng| StdRng{ rng })
     }
 }
@@ -430,7 +430,7 @@ impl SeedFromRng for StdRng {
 
 #[cfg(test)]
 mod test {
-    use {Rng, thread_rng, Sample, Result};
+    use {Rng, thread_rng, Sample, Error};
     use rand_core::mock::MockAddRng;
     use distributions::{uniform};
     use distributions::{Uniform, Range, Exp};
@@ -451,7 +451,7 @@ mod test {
         fn next_u128(&mut self) -> u128 {
             self.inner.next_u128()
         }
-        fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+        fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
             self.inner.try_fill(dest)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,9 @@ impl Rng for StdRng {
     fn next_u128(&mut self) -> u128 {
         self.rng.next_u128()
     }
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest);
+    }
     fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.rng.try_fill(dest)
     }
@@ -450,6 +453,9 @@ mod test {
         #[cfg(feature = "i128_support")]
         fn next_u128(&mut self) -> u128 {
             self.inner.next_u128()
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            self.inner.fill_bytes(dest)
         }
         fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
             self.inner.try_fill(dest)
@@ -486,7 +492,7 @@ mod test {
                        80, 81, 82, 83, 84, 85, 86, 87];
         for &n in lengths.iter() {
             let mut v = repeat(0u8).take(n).collect::<Vec<_>>();
-            r.try_fill(&mut v).unwrap();
+            r.fill_bytes(&mut v);
 
             // use this to get nicer error messages.
             for (i, &byte) in v.iter().enumerate() {

--- a/src/os.rs
+++ b/src/os.rs
@@ -50,17 +50,24 @@ impl Rng for OsRng {
         self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
         unsafe{ *(buf.as_ptr() as *const u32) }
     }
+
     fn next_u64(&mut self) -> u64 {
         let mut buf: [u8; 8] = [0; 8];
         self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
         unsafe{ *(buf.as_ptr() as *const u64) }
     }
+
     #[cfg(feature = "i128_support")]
     fn next_u128(&mut self) -> u128 {
         let mut buf: [u8; 16] = [0; 16];
         self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
         unsafe{ *(buf.as_ptr() as *const u128) }
     }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.try_fill(dest).unwrap();
+    }
+
     fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill(v)
     }

--- a/src/os.rs
+++ b/src/os.rs
@@ -14,7 +14,7 @@
 use std::{mem, fmt};
 use std::io::Read;
 
-use {Rng, Result};
+use {Rng, Error};
 // TODO: replace many of the panics below with Result error handling
 
 /// A random number generator that retrieves randomness straight from
@@ -39,7 +39,7 @@ pub struct OsRng(imp::OsRng);
 
 impl OsRng {
     /// Create a new `OsRng`.
-    pub fn new() -> Result<OsRng> {
+    pub fn new() -> Result<OsRng, Error> {
         imp::OsRng::new().map(OsRng)
     }
 }
@@ -61,7 +61,7 @@ impl Rng for OsRng {
         self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
         unsafe{ *(buf.as_ptr() as *const u128) }
     }
-    fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill(v)
     }
 }
@@ -77,7 +77,7 @@ impl fmt::Debug for OsRng {
 struct ReadRng<R> (R);
 
 impl<R: Read> ReadRng<R> {
-    fn try_fill(&mut self, mut buf: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, mut buf: &mut [u8]) -> Result<(), Error> {
         while buf.len() > 0 {
             match self.0.read(buf).unwrap_or_else(|e| panic!("Read error: {}", e)) {
                 0 => panic!("OsRng: no bytes available"),
@@ -99,10 +99,10 @@ mod imp {
 
     use self::OsRngInner::*;
     use super::ReadRng;
+    use Error;
 
     use std::io;
     use std::fs::File;
-    use Result;
 
     #[cfg(all(target_os = "linux",
               any(target_arch = "x86_64",
@@ -139,7 +139,7 @@ mod imp {
                       target_arch = "powerpc"))))]
     fn getrandom(_buf: &mut [u8]) -> libc::c_long { -1 }
 
-    fn getrandom_try_fill(v: &mut [u8]) -> Result<()> {
+    fn getrandom_try_fill(v: &mut [u8]) -> Result<(), Error> {
         let mut read = 0;
         let len = v.len();
         while read < len {
@@ -206,18 +206,18 @@ mod imp {
     }
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             if is_getrandom_available() {
                 return Ok(OsRng { inner: OsGetrandomRng });
             }
 
-            let reader = File::open("/dev/urandom")?;
+            let reader = File::open("/dev/urandom").unwrap();
             let reader_rng = ReadRng(reader);
 
             Ok(OsRng { inner: OsReadRng(reader_rng) })
         }
         
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             match self.inner {
                 OsGetrandomRng => getrandom_try_fill(v),
                 OsReadRng(ref mut rng) => rng.try_fill(v)
@@ -232,7 +232,6 @@ mod imp {
 
     use std::io;
     use self::libc::{c_int, size_t};
-    use Result;
 
     #[derive(Debug)]
     pub struct OsRng;
@@ -249,10 +248,10 @@ mod imp {
     }
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             Ok(OsRng)
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             let ret = unsafe {
                 SecRandomCopyBytes(kSecRandomDefault, v.len() as size_t, v.as_mut_ptr())
             };
@@ -269,16 +268,15 @@ mod imp {
     extern crate libc;
 
     use std::{io, ptr};
-    use Result;
 
     #[derive(Debug)]
     pub struct OsRng;
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             Ok(OsRng)
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             let mib = [libc::CTL_KERN, libc::KERN_ARND];
             // kern.arandom permits a maximum buffer size of 256 bytes
             for s in v.chunks_mut(256) {
@@ -303,16 +301,15 @@ mod imp {
     extern crate libc;
 
     use std::io;
-    use Result;
 
     #[derive(Debug)]
     pub struct OsRng;
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             Ok(OsRng)
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             // getentropy(2) permits a maximum buffer size of 256 bytes
             for s in v.chunks_mut(256) {
                 let ret = unsafe {
@@ -333,7 +330,6 @@ mod imp {
     use std::io;
     use std::fs::File;
     use super::ReadRng;
-    use Result;
 
     #[derive(Debug)]
     pub struct OsRng {
@@ -341,13 +337,13 @@ mod imp {
     }
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
-            let reader = File::open("rand:")?;
+        pub fn new() -> Result<OsRng, Error> {
+            let reader = File::open("rand:").unwrap();
             let reader_rng = ReadRng(reader);
 
             Ok(OsRng { inner: reader_rng })
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             self.inner.try_fill(v)
         }
     }
@@ -358,16 +354,15 @@ mod imp {
     extern crate fuchsia_zircon;
 
     use std::io;
-    use Result;
 
     #[derive(Debug)]
     pub struct OsRng;
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             Ok(OsRng)
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             for s in v.chunks_mut(fuchsia_zircon::ZX_CPRNG_DRAW_MAX_LEN) {
                 let mut filled = 0;
                 while filled < s.len() {
@@ -385,7 +380,6 @@ mod imp {
 #[cfg(windows)]
 mod imp {
     use std::io;
-    use Result;
 
     type BOOLEAN = u8;
     type ULONG = u32;
@@ -400,10 +394,10 @@ mod imp {
     pub struct OsRng;
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             Ok(OsRng)
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             // RtlGenRandom takes an ULONG (u32) for the length so we need to
             // split up the buffer.
             for slice in v.chunks_mut(<ULONG>::max_value() as usize) {
@@ -426,7 +420,6 @@ mod imp {
 
     use std::io;
     use std::mem;
-    use Result;
 
     #[derive(Debug)]
     pub struct OsRng(extern fn(dest: *mut libc::c_void,
@@ -449,7 +442,7 @@ mod imp {
     }
 
     impl OsRng {
-        pub fn new() -> Result<OsRng> {
+        pub fn new() -> Result<OsRng, Error> {
             let mut iface = NaClIRTRandom {
                 get_random_bytes: None,
             };
@@ -468,7 +461,7 @@ mod imp {
                 Err(Result)
             }
         }
-        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+        pub fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
             let mut read = 0;
             loop {
                 let mut r: libc::size_t = 0;

--- a/src/os.rs
+++ b/src/os.rs
@@ -46,22 +46,18 @@ impl OsRng {
 
 impl Rng for OsRng {
     fn next_u32(&mut self) -> u32 {
-        let mut buf: [u8; 4] = [0; 4];
-        self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
-        unsafe{ *(buf.as_ptr() as *const u32) }
+        // note: `next_u32_via_fill` does a byte-swap on big-endian
+        // architectures, which is not really needed here
+        ::rand_core::impls::next_u32_via_fill(self)
     }
 
     fn next_u64(&mut self) -> u64 {
-        let mut buf: [u8; 8] = [0; 8];
-        self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
-        unsafe{ *(buf.as_ptr() as *const u64) }
+        ::rand_core::impls::next_u64_via_fill(self)
     }
 
     #[cfg(feature = "i128_support")]
     fn next_u128(&mut self) -> u128 {
-        let mut buf: [u8; 16] = [0; 16];
-        self.try_fill(&mut buf).unwrap_or_else(|e| panic!("try_fill failed: {:?}", e));
-        unsafe{ *(buf.as_ptr() as *const u128) }
+        ::rand_core::impls::next_u128_via_fill(self)
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -11,7 +11,7 @@
 //! The ChaCha random number generator.
 
 use core::num::Wrapping as w;
-use {Rng, SeedFromRng, SeedableRng, Result};
+use {Rng, SeedFromRng, SeedableRng, Error};
 
 #[allow(bad_style)]
 type w32 = w<u32>;
@@ -208,7 +208,7 @@ impl Rng for ChaChaRng {
     
     // Custom implementation allowing larger reads from buffer is about 8%
     // faster than default implementation in my tests
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         use core::cmp::min;
         use core::intrinsics::{transmute, copy_nonoverlapping};
         
@@ -245,7 +245,7 @@ impl Rng for ChaChaRng {
 }
 
 impl SeedFromRng for ChaChaRng {
-    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self> {
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self, Error> {
         let mut key : [u32; KEY_WORDS] = [0; KEY_WORDS];
         for word in key.iter_mut() {
             *word = other.next_u32();

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -208,7 +208,7 @@ impl Rng for ChaChaRng {
     
     // Custom implementation allowing larger reads from buffer is about 8%
     // faster than default implementation in my tests
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
         use core::cmp::min;
         use core::intrinsics::{transmute, copy_nonoverlapping};
         
@@ -240,7 +240,6 @@ impl Rng for ChaChaRng {
             };
             left.copy_from_slice(&chunk[..n]);
         }
-        Ok(())
     }
 }
 

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -241,6 +241,10 @@ impl Rng for ChaChaRng {
             left.copy_from_slice(&chunk[..n]);
         }
     }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
 }
 
 impl SeedFromRng for ChaChaRng {

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -15,7 +15,7 @@ use core::iter::repeat;
 use core::num::Wrapping as w;
 use core::fmt;
 
-use {Rng, SeedFromRng, SeedableRng, Result};
+use {Rng, SeedFromRng, SeedableRng, Error};
 
 #[allow(non_camel_case_types)]
 type w32 = w<u32>;
@@ -281,13 +281,13 @@ impl Rng for IsaacRng {
         ::rand_core::impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         ::rand_core::impls::try_fill_via_u32(self, dest)
     }
 }
 
 impl SeedFromRng for IsaacRng {
-    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self> {
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self, Error> {
         let mut ret = EMPTY;
         unsafe {
             let ptr = ret.rsl.as_mut_ptr() as *mut u8;

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -281,8 +281,8 @@ impl Rng for IsaacRng {
         ::rand_core::impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        ::rand_core::impls::try_fill_via_u32(self, dest)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        ::rand_core::impls::fill_bytes_via_u32(self, dest);
     }
 }
 

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -284,6 +284,10 @@ impl Rng for IsaacRng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         ::rand_core::impls::fill_bytes_via_u32(self, dest);
     }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
 }
 
 impl SeedFromRng for IsaacRng {

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -270,6 +270,10 @@ impl Rng for Isaac64Rng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         ::rand_core::impls::fill_bytes_via_u32(self, dest);
     }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
 }
 
 impl SeedFromRng for Isaac64Rng {

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -15,7 +15,7 @@ use core::iter::repeat;
 use core::num::Wrapping as w;
 use core::fmt;
 
-use {Rng, SeedFromRng, SeedableRng, Result};
+use {Rng, SeedFromRng, SeedableRng, Error};
 
 #[allow(non_camel_case_types)]
 type w64 = w<u64>;
@@ -267,13 +267,13 @@ impl Rng for Isaac64Rng {
         ::rand_core::impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         ::rand_core::impls::try_fill_via_u32(self, dest)
     }
 }
 
 impl SeedFromRng for Isaac64Rng {
-    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self> {
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self, Error> {
         let mut ret = EMPTY_64;
         unsafe {
             let ptr = ret.rsl.as_mut_ptr() as *mut u8;

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -267,8 +267,8 @@ impl Rng for Isaac64Rng {
         ::rand_core::impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        ::rand_core::impls::try_fill_via_u32(self, dest)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        ::rand_core::impls::fill_bytes_via_u32(self, dest);
     }
 }
 

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -11,7 +11,7 @@
 //! The ISAAC random number generator.
 
 use core::fmt;
-use {Rng, SeedFromRng, Result};
+use {Rng, SeedFromRng, Error};
 
 #[cfg(target_pointer_width = "32")]
 type WordRngType = super::isaac::IsaacRng;
@@ -53,13 +53,13 @@ impl Rng for IsaacWordRng {
         self.0.next_u128()
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill(dest)
     }
 }
 
 impl SeedFromRng for IsaacWordRng {
-    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self> {
+    fn from_rng<R: Rng+?Sized>(other: &mut R) -> Result<Self, Error> {
         WordRngType::from_rng(other).map(|rng| IsaacWordRng(rng))
     }
 }

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -56,6 +56,10 @@ impl Rng for IsaacWordRng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        self.0.try_fill(dest)
+    }
 }
 
 impl SeedFromRng for IsaacWordRng {

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -53,8 +53,8 @@ impl Rng for IsaacWordRng {
         self.0.next_u128()
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.0.try_fill(dest)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
     }
 }
 

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -84,8 +84,8 @@ impl Rng for XorShiftRng {
         ::rand_core::impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        ::rand_core::impls::try_fill_via_u32(self, dest)
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        ::rand_core::impls::fill_bytes_via_u32(self, dest);
     }
 }
 

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -11,7 +11,7 @@
 //! Xorshift generators
 
 use core::num::Wrapping as w;
-use {Rng, SeedFromRng, SeedableRng, Result};
+use {Rng, SeedFromRng, SeedableRng, Error};
 
 /// An Xorshift[1] random number
 /// generator.
@@ -50,7 +50,7 @@ impl XorShiftRng {
 }
 
 impl SeedFromRng for XorShiftRng {
-    fn from_rng<R: Rng+?Sized>(rng: &mut R) -> Result<Self> {
+    fn from_rng<R: Rng+?Sized>(rng: &mut R) -> Result<Self, Error> {
         let mut tuple: (u32, u32, u32, u32);
         loop {
             tuple = (rng.next_u32(), rng.next_u32(), rng.next_u32(), rng.next_u32());
@@ -84,7 +84,7 @@ impl Rng for XorShiftRng {
         ::rand_core::impls::next_u128_via_u64(self)
     }
     
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         ::rand_core::impls::try_fill_via_u32(self, dest)
     }
 }

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -87,6 +87,10 @@ impl Rng for XorShiftRng {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         ::rand_core::impls::fill_bytes_via_u32(self, dest);
     }
+
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        Ok(self.fill_bytes(dest))
+    }
 }
 
 impl SeedableRng<[u32; 4]> for XorShiftRng {

--- a/src/read.rs
+++ b/src/read.rs
@@ -11,8 +11,8 @@
 //! A wrapper around any Read to treat it as an RNG.
 
 use std::fmt::Debug;
+use std::io;
 use std::io::Read;
-use std::mem;
 
 use {Rng, Error, ErrorKind};
 
@@ -21,7 +21,9 @@ use {Rng, Error, ErrorKind};
 ///
 /// # Panics
 ///
-/// It will panic if it there is insufficient data to fulfill a request.
+/// Only the `try_fill` method will report errors. All other methods will panic
+/// if the underlying reader encounters an error. They will also panic if there
+/// is insufficient data to fulfill a request.
 ///
 /// # Example
 ///
@@ -46,55 +48,43 @@ impl<R: Read + Debug> ReadRng<R> {
     }
 }
 
-macro_rules! impl_uint_from_fill {
-    ($ty:ty, $N:expr, $self:expr) => ({
-        // Transmute and convert from LE (i.e. byte-swap on BE)
-        assert_eq!($N, ::core::mem::size_of::<$ty>());
-        let mut buf = [0u8; $N];
-        fill(&mut $self.reader, &mut buf).unwrap();
-        unsafe{ *(buf.as_ptr() as *const $ty) }.to_le()
-    });
-}
-
 impl<R: Read + Debug> Rng for ReadRng<R> {
     fn next_u32(&mut self) -> u32 {
-        impl_uint_from_fill!(u32, 4, self)
+        ::rand_core::impls::next_u32_via_fill(self)
     }
 
     fn next_u64(&mut self) -> u64 {
-        impl_uint_from_fill!(u64, 8, self)
+        ::rand_core::impls::next_u64_via_fill(self)
     }
 
     #[cfg(feature = "i128_support")]
     fn next_u128(&mut self) -> u128 {
-        impl_uint_from_fill!(u128, 16, self)
+        ::rand_core::impls::next_u128_via_fill(self)
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.try_fill(dest).unwrap();
     }
 
-    fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
-        if v.len() == 0 { return Ok(()); }
-        fill(&mut self.reader, v)
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        if dest.len() == 0 { return Ok(()); }
+        // Use `std::io::read_exact`, which retries on `ErrorKind::Interrupted`.
+        self.reader.read_exact(dest).map_err(map_err)
     }
 }
 
-fn fill(r: &mut Read, mut buf: &mut [u8]) -> Result<(), Error> {
-    while buf.len() > 0 {
-        match r.read(buf) {
-            Ok(0) => return Err(Error::new(ErrorKind::Unavailable, None)),
-            Ok(n) => buf = &mut mem::replace(&mut buf, &mut [])[n..],
-            Err(_) => return Err(Error::new(ErrorKind::Other, None)),
-        }
-    }
-    Ok(())
+fn map_err(err: io::Error) -> Error {
+    let kind = match err.kind() {
+        io::ErrorKind::UnexpectedEof => ErrorKind::Unavailable,
+        _ => ErrorKind::Other,
+    };
+    Error::new(kind, Some(Box::new(err)))
 }
 
 #[cfg(test)]
 mod test {
     use super::ReadRng;
-    use Rng;
+    use {Rng, ErrorKind};
 
     #[test]
     fn test_reader_rng_u64() {
@@ -130,8 +120,11 @@ mod test {
 
     #[test]
     fn test_reader_rng_insufficient_bytes() {
-        let mut rng = ReadRng::new(&[][..]);
-        let mut v = [0u8; 3];
-        assert!(rng.try_fill(&mut v).is_err());
+        let v = [1u8, 2, 3, 4, 5, 6, 7, 8];
+        let mut w = [0u8; 9];
+
+        let mut rng = ReadRng::new(&v[..]);
+
+        assert!(rng.try_fill(&mut w).err().unwrap().kind == ErrorKind::Unavailable);
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use std::io::Read;
 use std::mem;
 
-use {Rng, Error, Result};
+use {Rng, Error, ErrorKind};
 
 /// An RNG that reads random bytes straight from a `Read`. This will
 /// work best with an infinite reader, but this is not required.
@@ -68,17 +68,18 @@ impl<R: Read + Debug> Rng for ReadRng<R> {
         impl_uint_from_fill!(u128, 16, self)
     }
     
-    fn try_fill(&mut self, v: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
         if v.len() == 0 { return Ok(()); }
         fill(&mut self.reader, v)
     }
 }
 
-fn fill(r: &mut Read, mut buf: &mut [u8]) -> Result<()> {
+fn fill(r: &mut Read, mut buf: &mut [u8]) -> Result<(), Error> {
     while buf.len() > 0 {
-        match r.read(buf)? {
-            0 => return Err(Error),
-            n => buf = &mut mem::replace(&mut buf, &mut [])[n..],
+        match r.read(buf) {
+            Ok(0) => return Err(Error::new(ErrorKind::Unavailable, None)),
+            Ok(n) => buf = &mut mem::replace(&mut buf, &mut [])[n..],
+            Err(_) => return Err(Error::new(ErrorKind::Other, None)),
         }
     }
     Ok(())

--- a/src/read.rs
+++ b/src/read.rs
@@ -60,14 +60,20 @@ impl<R: Read + Debug> Rng for ReadRng<R> {
     fn next_u32(&mut self) -> u32 {
         impl_uint_from_fill!(u32, 4, self)
     }
+
     fn next_u64(&mut self) -> u64 {
         impl_uint_from_fill!(u64, 8, self)
     }
+
     #[cfg(feature = "i128_support")]
     fn next_u128(&mut self) -> u128 {
         impl_uint_from_fill!(u128, 16, self)
     }
-    
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.try_fill(dest).unwrap();
+    }
+
     fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
         if v.len() == 0 { return Ok(()); }
         fill(&mut self.reader, v)
@@ -112,12 +118,12 @@ mod test {
         assert_eq!(rng.next_u32(), 3_u32.to_be());
     }
     #[test]
-    fn test_reader_rng_try_fill() {
+    fn test_reader_rng_fill_bytes() {
         let v = [1u8, 2, 3, 4, 5, 6, 7, 8];
         let mut w = [0u8; 8];
 
         let mut rng = ReadRng::new(&v[..]);
-        rng.try_fill(&mut w).unwrap();
+        rng.fill_bytes(&mut w);
 
         assert!(v == w);
     }

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -13,7 +13,7 @@
 
 use core::fmt::Debug;
 
-use {Rng, SeedableRng, Result};
+use {Rng, SeedableRng, Error};
 #[cfg(feature="std")]
 use NewSeeded;
 
@@ -80,7 +80,7 @@ impl<R: Rng, Rsdr: Reseeder<R>> Rng for ReseedingRng<R, Rsdr> {
         self.rng.next_u128()
     }
 
-    fn try_fill(&mut self, dest: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         self.reseed_if_necessary();
         self.bytes_generated += dest.len() as u64;
         self.rng.try_fill(dest)

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -40,7 +40,11 @@ impl Rng for ThreadRng {
     fn next_u128(&mut self) -> u128 {
         self.rng.borrow_mut().next_u128()
     }
-    
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.borrow_mut().fill_bytes(dest);
+    }
+
     fn try_fill(&mut self, bytes: &mut [u8]) -> Result<(), Error> {
         self.rng.borrow_mut().try_fill(bytes)
     }

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use {Rng, StdRng, NewSeeded, Rand, Default, Result};
+use {Rng, StdRng, NewSeeded, Rand, Default, Error};
 
 use reseeding::{ReseedingRng, ReseedWithNew};
 
@@ -41,7 +41,7 @@ impl Rng for ThreadRng {
         self.rng.borrow_mut().next_u128()
     }
     
-    fn try_fill(&mut self, bytes: &mut [u8]) -> Result<()> {
+    fn try_fill(&mut self, bytes: &mut [u8]) -> Result<(), Error> {
         self.rng.borrow_mut().try_fill(bytes)
     }
 }


### PR DESCRIPTION
This PR tries out some of the error handling we seem to be arriving at in the RFC tread.

For the error enum I have now:
```
pub enum Error {
    /// This RNG is permanently unavailable.
    NotAvailable,
    /// Needs (re)seeding. Depending on the RNG this can mean you have to wait
    /// and retry later, or you have to (re)seed it.
    EntropyLow,
    /// Failure, retry for a limited number of times.
    TemporaryFailure,
    /// Interrupted, usually by a signal from the OS.
    Interrupted,
    /// Any RNG error not part of this list.
    Other,
    #[doc(hidden)]
    __Nonexhaustive,
}
```

It occurred to me the variants `EntropyExhausted` and `NetYetSeeded` on the RFC thread are essentially the same, so I combined them into `EntropyLow`.

This commit partly undoes your work in https://github.com/dhardy/rand/commit/0a97209436092c30f55166fe047dd237ce5073d6, I am sorry.
Maybe it is just me being to inexperienced, but the `Result` with two arguments looks clearer to me. I think it helps documentation-wise, as you can now click on the return type `RngError` in rustdoc and see the various causes. Because we have only four different methods that can return a `Result`, it does not really seem an ergonomic loss.

The second commit adds back `fill_bytes`. I gave `try_fill` a default implementation in terms of `fill_bytes`. This makes implementation of PRNGs (which usually never error) slightly simpler, as they don't have to use Result. Wrappers become slightly more complex, as they have to wrap another method.

In the third commit I tried out the new error handling with `ReadRng`.


Actually I was working on the `OsRng` implementations, and did not plan on writing this :-).
So I have not touched the code in `os.rs` that much yet.