### PR TITLE
Common traits

### DIFF
--- a/src/os.rs
+++ b/src/os.rs
@@ -18,7 +18,9 @@ use {Rng, Error};
 // TODO: replace many of the panics below with Result error handling
 
 /// A random number generator that retrieves randomness straight from
-/// the operating system. Platform sources:
+/// the operating system.
+///
+/// Platform sources:
 ///
 /// - Unix-like systems (Linux, Android, Mac OSX): read directly from
 ///   `/dev/urandom`, or from `getrandom(2)` system call if available.
@@ -36,6 +38,12 @@ use {Rng, Error};
 /// [1] See <https://www.python.org/dev/peps/pep-0524/> for a more
 ///     in-depth discussion.
 pub struct OsRng(imp::OsRng);
+
+impl fmt::Debug for OsRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl OsRng {
     /// Create a new `OsRng`.
@@ -66,12 +74,6 @@ impl Rng for OsRng {
 
     fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
         self.0.try_fill(v)
-    }
-}
-
-impl fmt::Debug for OsRng {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "OsRng {{}}")
     }
 }
 

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -11,6 +11,7 @@
 //! The ChaCha random number generator.
 
 use core::num::Wrapping as w;
+use core::fmt;
 use {Rng, CryptoRng, SeedFromRng, SeedableRng, Error};
 
 #[allow(bad_style)]
@@ -29,11 +30,18 @@ const CHACHA_ROUNDS: u32 = 20; // Cryptographically secure from 8 upwards as of 
 ///
 /// [1]: D. J. Bernstein, [*ChaCha, a variant of
 /// Salsa20*](http://cr.yp.to/chacha.html)
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ChaChaRng {
     buffer:  [w32; STATE_WORDS], // Internal buffer of output
     state:   [w32; STATE_WORDS], // Initial state
     index:   usize,                 // Index into state
+}
+
+// Custom Debug implementation that does not expose the internal state
+impl fmt::Debug for ChaChaRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ChaChaRng {{}}")
+    }
 }
 
 macro_rules! quarter_round{

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -29,19 +29,12 @@ const CHACHA_ROUNDS: u32 = 20; // Cryptographically secure from 8 upwards as of 
 ///
 /// [1]: D. J. Bernstein, [*ChaCha, a variant of
 /// Salsa20*](http://cr.yp.to/chacha.html)
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct ChaChaRng {
     buffer:  [w32; STATE_WORDS], // Internal buffer of output
     state:   [w32; STATE_WORDS], // Initial state
     index:   usize,                 // Index into state
 }
-
-static EMPTY: ChaChaRng = ChaChaRng {
-    buffer:  [w(0); STATE_WORDS],
-    state:   [w(0); STATE_WORDS],
-    index:   STATE_WORDS
-};
-
 
 macro_rules! quarter_round{
     ($a: expr, $b: expr, $c: expr, $d: expr) => {{
@@ -102,7 +95,11 @@ impl ChaChaRng {
     /// - 2917185654
     /// - 2419978656
     pub fn new_unseeded() -> ChaChaRng {
-        let mut rng = EMPTY;
+        let mut rng = ChaChaRng {
+            buffer:  [w(0); STATE_WORDS],
+            state:   [w(0); STATE_WORDS],
+            index:   STATE_WORDS
+        };
         rng.init(&[0; KEY_WORDS]);
         rng
     }
@@ -265,7 +262,11 @@ impl<'a> SeedableRng<&'a [u32]> for ChaChaRng {
     /// Only up to 8 words are used; if less than 8
     /// words are used, the remaining are set to zero.
     fn from_seed(seed: &'a [u32]) -> ChaChaRng {
-        let mut rng = EMPTY;
+        let mut rng = ChaChaRng {
+            buffer:  [w(0); STATE_WORDS],
+            state:   [w(0); STATE_WORDS],
+            index:   STATE_WORDS
+        };
         rng.init(&[0u32; KEY_WORDS]);
         // set key in place
         {

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -110,6 +110,7 @@ impl Clone for IsaacRng {
     }
 }
 
+// Custom Debug implementation that does not expose the internal state
 impl fmt::Debug for IsaacRng {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "IsaacRng {{}}")

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -94,6 +94,7 @@ impl Clone for Isaac64Rng {
     }
 }
 
+// Custom Debug implementation that does not expose the internal state
 impl fmt::Debug for Isaac64Rng {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Isaac64Rng {{}}")

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -11,6 +11,7 @@
 //! Xorshift generators
 
 use core::num::Wrapping as w;
+use core::fmt;
 use {Rng, SeedFromRng, SeedableRng, Error};
 
 /// An Xorshift[1] random number
@@ -23,13 +24,19 @@ use {Rng, SeedFromRng, SeedableRng, Error};
 /// [1]: Marsaglia, George (July 2003). ["Xorshift
 /// RNGs"](http://www.jstatsoft.org/v08/i14/paper). *Journal of
 /// Statistical Software*. Vol. 8 (Issue 14).
-#[allow(missing_copy_implementations)]
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct XorShiftRng {
     x: w<u32>,
     y: w<u32>,
     z: w<u32>,
     w: w<u32>,
+}
+
+// Custom Debug implementation that does not expose the internal state
+impl fmt::Debug for XorShiftRng {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "XorShiftRng {{}}")
+    }
 }
 
 impl XorShiftRng {

--- a/src/read.rs
+++ b/src/read.rs
@@ -10,7 +10,6 @@
 
 //! A wrapper around any Read to treat it as an RNG.
 
-use std::fmt::Debug;
 use std::io;
 use std::io::Read;
 
@@ -35,11 +34,12 @@ use {Rng, Error, ErrorKind};
 /// println!("{:x}", distributions::uniform::<u32, _>(&mut rng));
 /// ```
 #[derive(Debug)]
-pub struct ReadRng<R: Debug> {
+// Do not derive Clone, because it could share the underlying reader
+pub struct ReadRng<R> {
     reader: R
 }
 
-impl<R: Read + Debug> ReadRng<R> {
+impl<R: Read> ReadRng<R> {
     /// Create a new `ReadRng` from a `Read`.
     pub fn new(r: R) -> ReadRng<R> {
         ReadRng {
@@ -48,7 +48,7 @@ impl<R: Read + Debug> ReadRng<R> {
     }
 }
 
-impl<R: Read + Debug> Rng for ReadRng<R> {
+impl<R: Read> Rng for ReadRng<R> {
     fn next_u32(&mut self) -> u32 {
         ::rand_core::impls::next_u32_via_fill(self)
     }

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -21,8 +21,7 @@ const THREAD_RNG_RESEED_THRESHOLD: u64 = 32_768;
 type ReseedingStdRng = ReseedingRng<StdRng, ReseedWithNew>;
 
 /// The thread-local RNG.
-#[derive(Clone)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, Debug)]
 pub struct ThreadRng {
     rng: Rc<RefCell<ReseedingStdRng>>,
 }


### PR DESCRIPTION
As discussed in https://github.com/dhardy/rand/issues/13, this removes the `Copy` trait from `Rng` implementations, and adds `Clone` and `Debug` where needed.

The Debug implementations look like this:
``` rust
OsRng {
    inner: OsGetrandomRng
}
StdRng {
    rng: IsaacWordRng(
        Isaac64Rng {}
    )
}
ThreadRng {
    rng: RefCell {
        value: ReseedingRng {
            rng: StdRng {
                rng: IsaacWordRng(
                    Isaac64Rng {}
                )
            },
            generation_threshold: 32768,
            bytes_generated: 0,
            reseeder: ReseedWithNew
        }
    }
}
ReadRng {
    reader: File {
        fd: 3,
        path: "/dev/urandom",
        read: true,
        write: false
    }
}
XorShiftRng {}
IsaacRng {}
Isaac64Rng {}
IsaacWordRng(
    Isaac64Rng {}
)
ChaChaRng {}
MockAddRng {
    v: 2,
    a: 1
}

```

(generated with)
``` rust
    use NewSeeded;
    use std::fs::File;
    use {StdRng, OsRng, ReadRng};
    use prng::{XorShiftRng, IsaacRng, Isaac64Rng, IsaacWordRng, ChaChaRng};
    println!("Debug:");
    println!("{:#?}", OsRng::new().unwrap());
    println!("{:#?}", StdRng::new().unwrap());
    println!("{:#?}", thread_rng());
    {
        let file = File::open("/dev/random").unwrap();
        let mut rng = ReadRng::new(file);
    }
    println!("{:#?}", XorShiftRng::new().unwrap());
    println!("{:#?}", IsaacRng::new().unwrap());
    println!("{:#?}", Isaac64Rng::new().unwrap());
    println!("{:#?}", IsaacWordRng::new().unwrap());
    println!("{:#?}", ChaChaRng::new().unwrap());
    println!("{:#?}", ::rand_core::mock::MockAddRng::new(2u32, 1u32));
```

It is not easily possible to implement `Clone` for `OsRng`, because on some operating systems it needs to read from `/dev/urandom`, anf `File` does not implement `Clone`.

I also did not implement `Clone` for `ReadRng`. If it is initialized with a reference to the underlying reader, the clone would share the same reader, not a clone of it. That seems like an easy footgun to me.