### PR TITLE
Fix unaligned cast in `impl_uint_from_fill`

### DIFF
--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -18,12 +18,9 @@
 //! Byte-swapping (like the std `to_le` functions) is only needed to convert
 //! to/from byte sequences, and since its purpose is reproducibility,
 //! non-reproducible sources (e.g. `OsRng`) need not bother with it.
-//! 
-//! Missing from here are implementations of `next_u*` in terms of `try_fill`.
-//! Currently `OsRng` handles these implementations itself.
-//! TODO: should we add more implementations?
 
 use core::intrinsics::transmute;
+use core::slice;
 use Rng;
 
 /// Implement `next_u64` via `next_u32`, little-endian order.
@@ -84,22 +81,29 @@ pub fn fill_bytes_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
 
 macro_rules! impl_uint_from_fill {
     ($self:expr, $ty:ty, $N:expr) => ({
-        // Transmute and convert from LE (i.e. byte-swap on BE)
         debug_assert!($N == ::core::mem::size_of::<$ty>());
-        let mut buf = [0u8; $N];
-        $self.fill_bytes(&mut buf);
-        unsafe{ *(buf.as_ptr() as *const $ty) }.to_le()
+
+        let mut int: $ty = 0;
+        unsafe {
+            let ptr = &mut int as *mut $ty as *mut u8;
+            let slice = slice::from_raw_parts_mut(ptr, $N);
+            $self.fill_bytes(slice);
+        }
+        int.to_le()
     });
 }
 
+/// Implement `next_u32` via `fill_bytes`, little-endian order.
 pub fn next_u32_via_fill<R: Rng+?Sized>(rng: &mut R) -> u32 {
     impl_uint_from_fill!(rng, u32, 4)
 }
 
+/// Implement `next_u64` via `fill_bytes`, little-endian order.
 pub fn next_u64_via_fill<R: Rng+?Sized>(rng: &mut R) -> u64 {
     impl_uint_from_fill!(rng, u64, 8)
 }
 
+/// Implement `next_u128` via `fill_bytes`, little-endian order.
 #[cfg(feature = "i128_support")]
 pub fn next_u128_via_fill<R: Rng+?Sized>(rng: &mut R) -> u128 {
     impl_uint_from_fill!(rng, u128, 16)


### PR DESCRIPTION
It seems to me doing an unsafe cast from `[u8; 4]` to `u32` is not right, because they have different minimum alignments. But this code was used by both `OsRng` and `ReadRng`, and did not seems to cause problems. No idea why.