### PR TITLE
Common error details, as @newpavlov's design

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -253,7 +253,7 @@ impl ErrorKind {
             ErrorKind::Unavailable => "permanent failure or unavailable",
             ErrorKind::Transient => "transient failure",
             ErrorKind::NotReady => "not ready yet",
-            ErrorKind::Other => "uncategorised error",
+            ErrorKind::Other => "uncategorised",
             ErrorKind::__Nonexhaustive => unreachable!(),
         }
     }
@@ -274,14 +274,12 @@ impl fmt::Display for ErrorDetails {
     }
 }
 
-// Impl is only used for ErrorDetails::Str case, but can't implement for an enum case
 #[cfg(feature="std")]
 impl ::std::error::Error for ErrorDetails {
     fn description(&self) -> &str {
         match *self {
-            ErrorDetails::None => "NA", // case shouldn't be used
             ErrorDetails::Str(ref s) => s,
-            ErrorDetails::Error(ref e) => e.description(),
+            _ => unreachable!(),
         }
     }
     
@@ -320,10 +318,10 @@ impl Error {
         Self { kind, details: ErrorDetails::Error(cause.into()) }
     }
     
-    /// Get a description of the details (from str or description of chained
-    /// error).
+    /// Get details on the error, if available (string message or chained
+    /// "cause").
     /// 
-    /// In the case of a chained error, the actual error may be obtained via
+    /// In the case of a chained error, the actual error can be obtained with
     /// `std::error::Error::cause`.
     pub fn details(&self) -> Option<&str> {
         match self.details {
@@ -336,7 +334,7 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RNG {}", self.kind.description())
+        write!(f, "RNG error: {}", self.kind.description())
     }
 }
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -283,15 +283,14 @@ impl ErrorKind {
 
 /// Error type of random number generators
 /// 
-/// This embeds an `ErrorKind` which can be matched over (the *kind* describes
-/// how the error should be handled, rather than what cause it), a *message* to
-/// tell users what happened, and optionally a *cause* (which chains back to
-/// the original error).
+/// This embeds an `ErrorKind` which can be matched over, a *message* to tell
+/// users what happened, and optionally a *cause* (which allows chaining back
+/// to the original error).
 /// 
 /// The cause is omitted in `no_std` mode (see `Error::new` for details).
 #[derive(Debug)]
 pub struct Error {
-    /// Error kind
+    /// Error kind. This enum is included to aid handling of errors.
     pub kind: ErrorKind,
     msg: &'static str,
     #[cfg(feature="std")]
@@ -331,7 +330,7 @@ impl Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RNG error: {}", self.kind.description())
+        write!(f, "RNG error [{}]: {}", self.kind.description(), self.msg())
     }
 }
 

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -248,8 +248,25 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
-    pub fn description(&self) -> &'static str {
-        match *self {
+    /// True if this kind of error may resolve itself on retry.
+    /// 
+    /// See also `should_wait()`.
+    pub fn should_retry(self) -> bool {
+        match self {
+            ErrorKind::Transient | ErrorKind::NotReady => true,
+            _ => false,
+        }
+    }
+    /// True if we should wait before retrying
+    pub fn should_wait(self) -> bool {
+        match self {
+            ErrorKind::NotReady => true,
+            _ => false,
+        }
+    }
+    /// A description of this error kind
+    pub fn description(self) -> &'static str {
+        match self {
             ErrorKind::Unavailable => "permanent failure or unavailable",
             ErrorKind::Transient => "transient failure",
             ErrorKind::NotReady => "not ready yet",

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -283,8 +283,12 @@ impl ErrorKind {
 
 /// Error type of random number generators
 /// 
-/// This embeds two things, an `ErrorKind`, which can be matched over, and
-/// optional details provided to `new_str` or `new_err`.
+/// This embeds an `ErrorKind` which can be matched over (the *kind* describes
+/// how the error should be handled, rather than what cause it), a *message* to
+/// tell users what happened, and optionally a *cause* (which chains back to
+/// the original error).
+/// 
+/// The cause is omitted in `no_std` mode (see `Error::new` for details).
 #[derive(Debug)]
 pub struct Error {
     /// Error kind
@@ -298,7 +302,12 @@ impl Error {
     /// Create a new instance, with specified kind, message, and optionally a
     /// chained cause.
     /// 
-    /// In `no_std` mode the *cause* is ignored.
+    /// Note: `stdError` is an alias for `std::error::Error`.
+    /// 
+    /// If not targetting `std` (i.e. `no_std`), this function is replaced by
+    /// another with the same prototype, except that there are no bounds on the
+    /// type `E` (because both `Box` and `stdError` are unavailable), and the
+    /// `cause` is ignored.
     #[cfg(feature="std")]
     pub fn new<E>(kind: ErrorKind, msg: &'static str, cause: Option<E>) -> Self
         where E: Into<Box<stdError + Send + Sync>>

--- a/src/read.rs
+++ b/src/read.rs
@@ -10,7 +10,6 @@
 
 //! A wrapper around any Read to treat it as an RNG.
 
-use std::io;
 use std::io::Read;
 
 use {Rng, Error, ErrorKind};
@@ -69,16 +68,9 @@ impl<R: Read> Rng for ReadRng<R> {
     fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         if dest.len() == 0 { return Ok(()); }
         // Use `std::io::read_exact`, which retries on `ErrorKind::Interrupted`.
-        self.reader.read_exact(dest).map_err(map_err)
+        self.reader.read_exact(dest).map_err(|err|
+            Error::new(ErrorKind::Unavailable, "ReadRng: read error", Some(err)))
     }
-}
-
-fn map_err(err: io::Error) -> Error {
-    let kind = match err.kind() {
-        io::ErrorKind::UnexpectedEof => ErrorKind::Unavailable,
-        _ => ErrorKind::Other,
-    };
-    Error::new(kind, "ReadRng: read error", Some(err))
 }
 
 #[cfg(test)]

--- a/src/read.rs
+++ b/src/read.rs
@@ -78,7 +78,7 @@ fn map_err(err: io::Error) -> Error {
         io::ErrorKind::UnexpectedEof => ErrorKind::Unavailable,
         _ => ErrorKind::Other,
     };
-    Error::new(kind, Some(Box::new(err)))
+    Error::new_err(kind, err)
 }
 
 #[cfg(test)]

--- a/src/read.rs
+++ b/src/read.rs
@@ -78,7 +78,7 @@ fn map_err(err: io::Error) -> Error {
         io::ErrorKind::UnexpectedEof => ErrorKind::Unavailable,
         _ => ErrorKind::Other,
     };
-    Error::new_err(kind, err)
+    Error::new(kind, "ReadRng: read error", Some(err))
 }
 
 #[cfg(test)]

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -135,7 +135,6 @@ mod test {
     use std::iter::repeat;
     use mock::MockAddRng;
     use {SeedableRng, Rng, iter};
-    use distributions::ascii_word_char;
     use super::{ReseedingRng, Reseeder};
     
     #[derive(Debug)]
@@ -161,10 +160,11 @@ mod test {
 
     #[test]
     fn test_rng_seeded() {
+        // Default seed threshold is way beyond what we use here
         let mut ra: MyRng = SeedableRng::from_seed((ReseedMock, 2));
-        let mut rb: MyRng = SeedableRng::from_seed((ReseedMock, 2));
-        assert!(::test::iter_eq(iter(&mut ra).map(|rng| ascii_word_char(rng)).take(100),
-                                iter(&mut rb).map(|rng| ascii_word_char(rng)).take(100)));
+        let mut rb: MockAddRng<u32> = SeedableRng::from_seed(2);
+        assert!(::test::iter_eq(iter(&mut ra).map(|rng| rng.next_u32()).take(100),
+                                iter(&mut rb).map(|rng| rng.next_u32()).take(100)));
     }
 
     const FILL_BYTES_V_LEN: usize = 13579;


### PR DESCRIPTION
Implement new design in #10.

Any comments @newpavlov or @pitdicker?

`Error` should be 32 bytes in size (two enums padded for alignment + a fat pointer). It could potentially be reduced to 24 bytes by combining the two enums, but that would be ugly. Otherwise it could only be much smaller by omitting the details altogether. Hopefully the size doesn't make too much of a difference anyway; I don't know.

Most of the "details" implementation is hidden and "kind" is still not exhaustively matchable.

[Doc here](https://dhardy.github.io/rand/rand_core/struct.Error.html)