### PR TITLE
Implicit error handling (#25)

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -97,9 +97,15 @@ pub mod impls;
 /// 
 /// PRNGs are usually infallible, while external generators may fail. Since
 /// errors are rare and may be hard for the user to handle, most of the output
-/// functions only allow errors to be reported as panics; byte output can
-/// however be retrieved from `try_fill` which allows for the usual error
-/// handling.
+/// functions do not return a `Result`; byte output can however be retrieved
+/// with `try_fill` which allows for the usual error handling. If the random
+/// source implements other output functions in terms of `try_fill` (see
+/// `impls::fill_via_try_fill`), then some errors will be handled implicitly,
+/// so long as not too many retries are needed (specifically: `NotReady` is
+/// handled by waiting up to 1 minute, and `Transient` is handled by retrying
+/// a few times). In some applications it may make sense to ensure your entropy
+/// source (e.g. `OsRng`) is ready by calling `try_fill` explicitly before
+/// using any of the other output functions.
 pub trait Rng {
     /// Return the next random u32.
     fn next_u32(&mut self) -> u32;
@@ -266,11 +272,6 @@ impl ErrorKind {
     /// This implies `should_retry()` is true.
     pub fn should_wait(self) -> bool {
         self == ErrorKind::NotReady
-    }
-    
-    /// True if we should limit the number of retries before giving up.
-    pub fn limit_retries(self) -> bool {
-        self == ErrorKind::Transient
     }
     
     /// A description of this error kind

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -260,15 +260,19 @@ impl ErrorKind {
             _ => false,
         }
     }
+    
     /// True if we should retry but wait before retrying
     /// 
     /// This implies `should_retry()` is true.
     pub fn should_wait(self) -> bool {
-        match self {
-            ErrorKind::NotReady => true,
-            _ => false,
-        }
+        self == ErrorKind::NotReady
     }
+    
+    /// True if we should limit the number of retries before giving up.
+    pub fn limit_retries(self) -> bool {
+        self == ErrorKind::Transient
+    }
+    
     /// A description of this error kind
     pub fn description(self) -> &'static str {
         match self {

--- a/src/os.rs
+++ b/src/os.rs
@@ -68,7 +68,7 @@ impl Rng for OsRng {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.try_fill(dest).unwrap();
+        ::rand_core::impls::fill_via_try_fill(self, dest)
     }
 
     fn try_fill(&mut self, v: &mut [u8]) -> Result<(), Error> {
@@ -152,7 +152,7 @@ mod imp {
                     continue;
                 } else {
                     return Err(Error::new_with_cause(
-                        ErrorKind::Other,
+                        ErrorKind::Unavailable,
                         "unexpected getrandom error",
                         err,
                     ));

--- a/src/read.rs
+++ b/src/read.rs
@@ -62,7 +62,7 @@ impl<R: Read> Rng for ReadRng<R> {
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.try_fill(dest).unwrap();
+        ::rand_core::impls::fill_via_try_fill(self, dest)
     }
 
     fn try_fill(&mut self, dest: &mut [u8]) -> Result<(), Error> {


### PR DESCRIPTION
Add rand_core::impls::fill_via_try_fill with handling for errors.

I'm not completely happy about this but it does roughly meet the requirements in #25.

Using a global error counter is a bit weird, but seems better than adding a local error counter (e.g. `ReadRng` uses this impl, but can't actually emit the `Transient` error in any case).

In fact, no current code emits either `Transient` or `NotReady`.

Also, I think the best option for printing error causes when panicking is to log?