### PR TITLE
Log feature: optional logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ rand_core = { path = 'rand_core', default-features = false }
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", optional = true }
 
+log = { version = "0.4", optional = true }
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "profileapi", "winnt"] }
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ support.
 Version `0.5` is in development and contains significant performance
 improvements for the ISAAC random number generators.
 
+### Optional features
+
+The `rand` crate has some optional features:
+
+*   `--no-default-features` (otherwise known as `no_std`): build without `std`;
+    several features must be disabled including default entropy sources
+*   `nightly`: enables all nightly features (`i128_support`)
+*   `i128_support` (requires nightly rustc): add support for `i128` and `u128`
+*   `log`: do some logging via the `log` crate
+
 ## Examples
 
 There is built-in support for a random number generator (RNG) associated with


### PR DESCRIPTION
Implement #39 

I'm not very happy with this code.

Maybe there should be some code to log error details including causes somewhere? Or format to one long string? (But I think it's better to output each cause separately.)

I could probably get rid of all the `#[cfg(feature="log")]` by re-implementing `warn` and other macros locally (extra boilerplate in `lib.rs`).

I'm also not sure how many details to print when we just delay or skip reseeding.