### PR TITLE
Fix `JitterRng` on Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,10 @@ matrix:
       rust: nightly
 
     # Testing other channels
-    # Don't run nightly tests on darwin: JitterRng bench fails due to low-res timer
     - env: TARGET=x86_64-unknown-linux-gnu NIGHTLY=1
+      rust: nightly
+    - env: TARGET=x86_64-apple-darwin NIGHTLY=1
+      os: osx
       rust: nightly
 
 before_install:


### PR DESCRIPTION
Use `libc::mach_absolute_time` instead of `std::time::SystemTime`.