### PR TITLE
Avoid low bits

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![cfg_attr(feature = "i128_support", feature(i128_type, i128))]
 
 extern crate test;
 extern crate rand;
@@ -46,7 +47,9 @@ macro_rules! distr_range_int {
 distr_range_int!(distr_range_i8, i8, 20i8, 100);
 distr_range_int!(distr_range_i16, i16, -500i16, 2000);
 distr_range_int!(distr_range_i32, i32, -200_000_000i32, 800_000_000);
-distr_range_int!(distr_range_i64, i64, 3i64, 134217671);
+distr_range_int!(distr_range_i64, i64, 3i64, 12345678901234);
+#[cfg(feature = "i128_support")]
+distr_range_int!(distr_range_i128, i128, -12345678901234i128, 12345678901234567890);
 
 macro_rules! distr_float {
     ($fnn:ident, $ty:ty, $distr:expr) => {

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -67,3 +67,29 @@ distr!(distr_normal, f64, Normal::new(-2.71828, 3.14159));
 distr!(distr_log_normal, f64, LogNormal::new(-2.71828, 3.14159));
 distr!(distr_gamma_large_shape, f64, Gamma::new(10., 1.0));
 distr!(distr_gamma_small_shape, f64, Gamma::new(0.1, 1.0));
+
+
+// construct and sample from a range
+macro_rules! gen_range_int {
+    ($fnn:ident, $ty:ty, $low:expr, $high:expr) => {
+        #[bench]
+        fn $fnn(b: &mut Bencher) {
+            let mut rng = XorShiftRng::new().unwrap();
+
+            b.iter(|| {
+                for _ in 0..::RAND_BENCH_N {
+                    let x: $ty = Range::new($low, $high).sample(&mut rng);
+                    black_box(x);
+                }
+            });
+            b.bytes = size_of::<$ty>() as u64 * ::RAND_BENCH_N;
+        }
+    }
+}
+
+gen_range_int!(gen_range_i8, i8, 20i8, 100);
+gen_range_int!(gen_range_i16, i16, -500i16, 2000);
+gen_range_int!(gen_range_i32, i32, -200_000_000i32, 800_000_000);
+gen_range_int!(gen_range_i64, i64, 3i64, 12345678901234);
+#[cfg(feature = "i128_support")]
+gen_range_int!(gen_range_i128, i128, -12345678901234i128, 12345678901234567890);

--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -9,49 +9,11 @@ const RAND_BENCH_N: u64 = 1000;
 use std::mem::size_of;
 use test::{black_box, Bencher};
 
-use rand::{Default, Rand, NewSeeded};
+use rand::NewSeeded;
 use rand::prng::XorShiftRng;
 use rand::distributions::*;
 
-
-#[bench]
-fn distr_baseline(b: &mut Bencher) {
-    let mut rng = XorShiftRng::new().unwrap();
-
-    b.iter(|| {
-        for _ in 0..::RAND_BENCH_N {
-            black_box(u64::rand(&mut rng, Default));
-        }
-    });
-    b.bytes = size_of::<u64>() as u64 * ::RAND_BENCH_N;
-}
-
-macro_rules! distr_range_int {
-    ($fnn:ident, $ty:ty, $low:expr, $high:expr) => {
-        #[bench]
-        fn $fnn(b: &mut Bencher) {
-            let mut rng = XorShiftRng::new().unwrap();
-            let distr = Range::new($low, $high);
-
-            b.iter(|| {
-                for _ in 0..::RAND_BENCH_N {
-                    let x: $ty = distr.sample(&mut rng);
-                    black_box(x);
-                }
-            });
-            b.bytes = size_of::<$ty>() as u64 * ::RAND_BENCH_N;
-        }
-    }
-}
-
-distr_range_int!(distr_range_i8, i8, 20i8, 100);
-distr_range_int!(distr_range_i16, i16, -500i16, 2000);
-distr_range_int!(distr_range_i32, i32, -200_000_000i32, 800_000_000);
-distr_range_int!(distr_range_i64, i64, 3i64, 12345678901234);
-#[cfg(feature = "i128_support")]
-distr_range_int!(distr_range_i128, i128, -12345678901234i128, 12345678901234567890);
-
-macro_rules! distr_float {
+macro_rules! distr {
     ($fnn:ident, $ty:ty, $distr:expr) => {
         #[bench]
         fn $fnn(b: &mut Bencher) {
@@ -69,16 +31,39 @@ macro_rules! distr_float {
     }
 }
 
-distr_float!(distr_uniform01_float32, f32, Uniform01);
-distr_float!(distr_closed01_float32, f32, Closed01);
-distr_float!(distr_open01_float32, f32, Open01);
+// range
+distr!(distr_range_i8, i8, Range::new(20i8, 100));
+distr!(distr_range_i16, i16, Range::new(-500i16, 2000));
+distr!(distr_range_i32, i32, Range::new(-200_000_000i32, 800_000_000));
+distr!(distr_range_i64, i64, Range::new(3i64, 12345678901234));
+#[cfg(feature = "i128_support")]
+distr!(distr_range_i128, i128, Range::new(-12345678901234i128, 12345678901234567890));
 
-distr_float!(distr_uniform01_float, f64, Uniform01);
-distr_float!(distr_closed01_float, f64, Closed01);
-distr_float!(distr_open01_float, f64, Open01);
-distr_float!(distr_range_float, f64, Range::new(2.26f64, 2.319f64));
-distr_float!(distr_exp, f64, Exp::new(2.71828 * 3.14159));
-distr_float!(distr_normal, f64, Normal::new(-2.71828, 3.14159));
-distr_float!(distr_log_normal, f64, LogNormal::new(-2.71828, 3.14159));
-distr_float!(distr_gamma_large_shape, f64, Gamma::new(10., 1.0));
-distr_float!(distr_gamma_small_shape, f64, Gamma::new(0.1, 1.0));
+distr!(distr_range_float32, f32, Range::new(2.26f32, 2.319));
+distr!(distr_range_float, f64, Range::new(2.26f64, 2.319));
+
+// uniform
+distr!(distr_uniform_i8, i8, Uniform);
+distr!(distr_uniform_i16, i16, Uniform);
+distr!(distr_uniform_i32, i32, Uniform);
+distr!(distr_uniform_i64, i64, Uniform);
+#[cfg(feature = "i128_support")]
+distr!(distr_uniform_i128, i128, Uniform);
+
+distr!(distr_uniform_bool, bool, Uniform);
+distr!(distr_uniform_ascii_char, char, AsciiWordChar);
+
+distr!(distr_uniform01_float32, f32, Uniform01);
+distr!(distr_closed01_float32, f32, Closed01);
+distr!(distr_open01_float32, f32, Open01);
+
+distr!(distr_uniform01_float, f64, Uniform01);
+distr!(distr_closed01_float, f64, Closed01);
+distr!(distr_open01_float, f64, Open01);
+
+// distributions
+distr!(distr_exp, f64, Exp::new(2.71828 * 3.14159));
+distr!(distr_normal, f64, Normal::new(-2.71828, 3.14159));
+distr!(distr_log_normal, f64, LogNormal::new(-2.71828, 3.14159));
+distr!(distr_gamma_large_shape, f64, Gamma::new(10., 1.0));
+distr!(distr_gamma_small_shape, f64, Gamma::new(0.1, 1.0));

--- a/src/distributions/mod.rs
+++ b/src/distributions/mod.rs
@@ -165,6 +165,8 @@ fn ziggurat<R: Rng+?Sized, P, Z>(
         // Of the remaining 11 least significant bits we use 8 to construct `i`.
         // This saves us generating a whole extra random number, while the added
         // precision of using 64 bits for f64 does not buy us much.
+        // Because for some RNG's the least significant bits can be of lower
+        // statistical quality, we use bits 3..10 for i.
         let bits: u64 = uniform(rng);
 
         // u is either U(-1, 1) or U(0, 1) depending on if this is a
@@ -176,7 +178,7 @@ fn ziggurat<R: Rng+?Sized, P, Z>(
                 } else {
                     bits.closed_open01_fixed()
                 };
-        let i = (bits & 0xff) as usize;
+        let i = ((bits >> 3) & 0xff) as usize;
 
         let x = u * x_tab[i];
 

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -184,7 +184,11 @@ impl Distribution<u128> for Uniform {
 impl Distribution<bool> for Uniform {
     #[inline]
     fn sample<R: Rng+?Sized>(&self, rng: &mut R) -> bool {
-        rng.next_u32() & 1 == 1
+        // We can compare against an arbitrary bit of an u32 to get a bool.
+        // Because the least significant bits of a lower quality RNG can have
+        // simple patterns, we compare against the most significant bit. This is
+        // easiest done using a sign test.
+        (rng.next_u32() as i32) < 0
     }
 }
 


### PR DESCRIPTION
This implements https://github.com/dhardy/rand/issues/52#issuecomment-345014749.

Many small RNG's are of lower quality in their least significant bits. For example LCG's with a power of two modulus, MCG's, Xorshift+ and Xoroshiro+.

If it costs us nothing to avoid the least significant bits it seems sensible to me to do so. Even if none of these RNG's becomes part of rand itself.