### PR TITLE
Add sample_single to Range

### DIFF
--- a/benches/distributions.rs
+++ b/benches/distributions.rs
@@ -75,11 +75,13 @@ macro_rules! gen_range_int {
         #[bench]
         fn $fnn(b: &mut Bencher) {
             let mut rng = XorShiftRng::new().unwrap();
+            let high = $high;
 
             b.iter(|| {
                 for _ in 0..::RAND_BENCH_N {
-                    let x: $ty = Range::new($low, $high).sample(&mut rng);
+                    let x: $ty = Range::sample_single($low, high, &mut rng);
                     black_box(x);
+                    black_box(high);
                 }
             });
             b.bytes = size_of::<$ty>() as u64 * ::RAND_BENCH_N;

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -66,6 +66,13 @@ impl Range<RangeInt<i32>> {
         assert!(low < high, "Range::new called with `low >= high`");
         Range { inner: RangeImpl::new_inclusive(low, high) }
     }
+
+    /// Sample a single value uniformly from `[low, high)`.
+    /// Panics if `low >= high`.
+    pub fn sample_single<X: SampleRange, R: Rng+?Sized>(low: X, high: X, rng: &mut R) -> X {
+        assert!(low < high, "Range::sample_single called with low >= high");
+        X::T::sample_single(low, high, rng)
+    }
 }
 
 impl<T: RangeImpl> Distribution<T::X> for Range<T> {
@@ -94,6 +101,10 @@ pub trait RangeImpl {
 
     /// Sample a value.
     fn sample<R: Rng+?Sized>(&self, rng: &mut R) -> Self::X;
+
+    /// Sample a single value.
+    fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R)
+        -> Self::X;
 }
 
 /// Implementation of `RangeImpl` for integer types.
@@ -203,9 +214,9 @@ macro_rules! range_int_impl {
                     loop {
                         let v: $u_large = Rand::rand(rng, Uniform);
                         if $use_mult {
-                            let (high, low) = v.wmul(range);
-                            if low <= zone {
-                                return self.low.wrapping_add(high as $ty);
+                            let (hi, lo) = v.wmul(range);
+                            if lo <= zone {
+                                return self.low.wrapping_add(hi as $ty);
                             }
                         } else {
                             if v <= zone {
@@ -216,6 +227,37 @@ macro_rules! range_int_impl {
                 } else {
                     // Sample from the entire integer range.
                     Rand::rand(rng, Uniform)
+                }
+            }
+
+            fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R) -> Self::X {
+                let range = (high as $u_large)
+                            .wrapping_sub(low as $u_large);
+                let zone =
+                    if ::core::$unsigned::MAX <= ::core::u16::MAX as $unsigned {
+                        // Using a modulus is faster than the approximation for
+                        // i8 and i16. I suppose we trade the cost of one
+                        // modulus for near-perfect branch prediction.
+                        let unsigned_max: $u_large = ::core::$u_large::MAX;
+                        let ints_to_reject = (unsigned_max - range + 1) % range;
+                        unsigned_max - ints_to_reject
+                    } else {
+                        // conservative but fast approximation
+                       range << range.leading_zeros()
+                    };
+
+                loop {
+                    let v: $u_large = Rand::rand(rng, Uniform);
+                    if $use_mult {
+                        let (hi, lo) = v.wmul(range);
+                        if lo <= zone {
+                            return low.wrapping_add(hi as $ty);
+                        }
+                    } else {
+                        if v <= zone {
+                            return low.wrapping_add((v % range) as $ty);
+                        }
+                    }
                 }
             }
         }
@@ -448,6 +490,11 @@ macro_rules! range_float_impl {
                     }
                 }
             }
+
+            fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R) -> Self::X {
+                let range: Self = RangeImpl::new(low, high);
+                range.sample(rng)
+            }
         }
     }
 }
@@ -575,6 +622,10 @@ mod tests {
             }
             fn sample<R: Rng+?Sized>(&self, rng: &mut R) -> Self::X {
                 MyF32 { x: self.inner.sample(rng) }
+            }
+            fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R) -> Self::X {
+                let range: Self = RangeImpl::new(low, high);
+                range.sample(rng)
             }
         }
         impl SampleRange for MyF32 {

--- a/src/distributions/range.rs
+++ b/src/distributions/range.rs
@@ -87,7 +87,7 @@ pub trait SampleRange: PartialOrd+Sized {
 }
 
 /// Helper trait handling actual range sampling.
-pub trait RangeImpl {
+pub trait RangeImpl: Sized {
     /// The type sampled by this implementation.
     type X: PartialOrd;
 
@@ -104,7 +104,11 @@ pub trait RangeImpl {
 
     /// Sample a single value.
     fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R)
-        -> Self::X;
+        -> Self::X
+    {
+        let range: Self = RangeImpl::new(low, high);
+        range.sample(rng)
+    }
 }
 
 /// Implementation of `RangeImpl` for integer types.
@@ -490,11 +494,6 @@ macro_rules! range_float_impl {
                     }
                 }
             }
-
-            fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R) -> Self::X {
-                let range: Self = RangeImpl::new(low, high);
-                range.sample(rng)
-            }
         }
     }
 }
@@ -622,10 +621,6 @@ mod tests {
             }
             fn sample<R: Rng+?Sized>(&self, rng: &mut R) -> Self::X {
                 MyF32 { x: self.inner.sample(rng) }
-            }
-            fn sample_single<R: Rng+?Sized>(low: Self::X, high: Self::X, rng: &mut R) -> Self::X {
-                let range: Self = RangeImpl::new(low, high);
-                range.sample(rng)
             }
         }
         impl SampleRange for MyF32 {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -54,12 +54,17 @@ pub fn codepoint<R: Rng+?Sized>(rng: &mut R) -> char {
 /// TODO: should this be removed in favour of `AsciiWordChar`?
 #[inline]
 pub fn ascii_word_char<R: Rng+?Sized>(rng: &mut R) -> char {
-    use sequences::Choose;
+    const RANGE: u32 = 26 + 26 + 10;
     const GEN_ASCII_STR_CHARSET: &'static [u8] =
         b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
             abcdefghijklmnopqrstuvwxyz\
             0123456789";
-    *GEN_ASCII_STR_CHARSET.choose(rng).unwrap() as char
+    loop {
+        let var = rng.next_u32() & 0x3F;
+        if var < RANGE {
+            return GEN_ASCII_STR_CHARSET[var as usize] as char
+        }
+    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,8 +425,7 @@ pub trait Sample: Rng {
     /// }
     /// ```
     fn gen_range<T: SampleRange>(&mut self, low: T, high: T) -> T {
-        assert!(low < high, "Sample::gen_range called with low >= high");
-        Range::new(low, high).sample(self)
+        Range::sample_single(low, high, self)
     }
     
     /// Construct an iterator on an `Rng`.


### PR DESCRIPTION
As discussed in https://github.com/dhardy/rand/pull/68.

Benchmarks before (with `i128_support`):
```
test gen_range_i8             ... bench:       6,912 ns/iter (+/- 6) = 144 MB/s
test gen_range_i16            ... bench:       6,491 ns/iter (+/- 11) = 308 MB/s
test gen_range_i32            ... bench:       7,274 ns/iter (+/- 48) = 549 MB/s
test gen_range_i64            ... bench:      11,476 ns/iter (+/- 36) = 697 MB/s
test gen_range_i128           ... bench:     279,477 ns/iter (+/- 552) = 57 MB/s
```

After:
```
test gen_range_i8             ... bench:       5,350 ns/iter (+/- 5) = 186 MB/s
test gen_range_i16            ... bench:       5,347 ns/iter (+/- 3) = 374 MB/s
test gen_range_i32            ... bench:       3,922 ns/iter (+/- 22) = 1019 MB/s
test gen_range_i64            ... bench:       8,228 ns/iter (+/- 35) = 972 MB/s
test gen_range_i128           ... bench:     148,177 ns/iter (+/- 322) = 107 MB/s
```

And the normal code with a one-time set-up cost for comparison:
```
test distr_range_i8           ... bench:       2,685 ns/iter (+/- 27) = 372 MB/s
test distr_range_i16          ... bench:       2,866 ns/iter (+/- 29) = 697 MB/s
test distr_range_i32          ... bench:       3,361 ns/iter (+/- 53) = 1190 MB/s
test distr_range_i64          ... bench:       3,321 ns/iter (+/- 64) = 2408 MB/s
test distr_range_i128         ... bench:     140,754 ns/iter (+/- 1,327) = 113 MB/s
```

The performance of `sample_single` depends quite a bit on how close the range is to a power of two, but I have not investigated the details... Performance seems worth the extra method.

I am not sure the order of arguments is the best choice, with `(low, high, rng)`. Would `(rng, low, high)` be better?
Also I tried to make `sample_single` have a default implementation, like in `RangeFloat`, but couldn't get it to work.