### PR TITLE
Make from_rng require CryptoRng

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -183,6 +183,8 @@ impl<'a, R: Rng+?Sized> Rng for &'a mut R {
     }
 }
 
+impl<'a, R: CryptoRng+?Sized> CryptoRng for &'a mut R {}
+
 #[cfg(feature="std")]
 impl<R: Rng+?Sized> Rng for Box<R> {
     fn next_u32(&mut self) -> u32 {
@@ -206,6 +208,8 @@ impl<R: Rng+?Sized> Rng for Box<R> {
         (**self).try_fill(dest)
     }
 }
+
+impl<R: CryptoRng+?Sized> CryptoRng for Box<R> {}
 
 
 mod private {
@@ -256,7 +260,7 @@ pub trait SeedableRng: Sized {
     /// hand, seeding a simple numerical generator from another of the same
     /// type sometimes has serious side effects such as effectively cloning the
     /// generator.
-    fn from_rng<R: Rng>(mut rng: R) -> Result<Self, Error> {
+    fn from_rng<R: CryptoRng>(mut rng: R) -> Result<Self, Error> {
         let mut seed = Self::Seed::default();
         let size = mem::size_of::<Self::Seed>() as usize;
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,7 +487,7 @@ impl SeedableRng for StdRng {
     fn from_seed(seed: Self::Seed) -> Self {
         StdRng(IsaacWordRng::from_seed(seed))
     }
-    fn from_rng<R: Rng>(rng: R) -> Result<Self, Error> {
+    fn from_rng<R: CryptoRng>(rng: R) -> Result<Self, Error> {
         IsaacWordRng::from_rng(rng).map(|rng| StdRng(rng))
     }
 }

--- a/src/os.rs
+++ b/src/os.rs
@@ -14,7 +14,7 @@
 use std::fmt;
 use std::io::Read;
 
-use {Rng, Error, ErrorKind};
+use {CryptoRng, Rng, Error, ErrorKind};
 // TODO: replace many of the panics below with Result error handling
 
 /// A random number generator that retrieves randomness straight from
@@ -76,6 +76,8 @@ impl Rng for OsRng {
         self.0.try_fill(v)
     }
 }
+
+impl CryptoRng for OsRng {}
 
 // Specialisation of `ReadRng` for our purposes
 #[derive(Debug)]

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -236,7 +236,7 @@ impl SeedableRng for ChaChaRng {
 
 #[cfg(test)]
 mod test {
-    use {Rng, SeedableRng};
+    use {Rng, SeedableRng, thread_rng};
     use super::ChaChaRng;
 
     #[test]
@@ -246,7 +246,7 @@ mod test {
         let mut ra = ChaChaRng::from_hashable("some weak seed");
         ra.next_u32();
         */
-        let mut rb = ChaChaRng::from_rng(&mut ::test::rng()).unwrap();
+        let mut rb = ChaChaRng::from_rng(&mut thread_rng()).unwrap();
         rb.next_u32();
         
         let seed = [0,0,0,0,0,0,0,0,

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -375,6 +375,7 @@ mod test {
         let mut rng2 = IsaacRng::from_seed(seed);
         assert_eq!(rng2.next_u32(), 2869442790);
 
+        // FIXME
         let mut rng3 = IsaacRng::from_rng(&mut rng2).unwrap();
         assert_eq!(rng3.next_u32(), 3094074039);
     }

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -355,6 +355,7 @@ mod test {
         let mut rng2 = Isaac64Rng::from_seed(seed);
         assert_eq!(rng2.next_u64(), 14964555543728284049);
 
+        // FIXME
         let mut rng3 = Isaac64Rng::from_rng(&mut rng2).unwrap();
         assert_eq!(rng3.next_u64(), 919595328260451758);
     }

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -10,7 +10,7 @@
 
 //! The ISAAC random number generator.
 
-use {Rng, SeedableRng, Error};
+use {CryptoRng, Rng, SeedableRng, Error};
 
 #[cfg(target_pointer_width = "32")]
 type WordRngType = super::isaac::IsaacRng;
@@ -62,7 +62,7 @@ impl SeedableRng for IsaacWordRng {
         IsaacWordRng(WordRngType::from_seed(seed))
     }
 
-    fn from_rng<R: Rng>(rng: R) -> Result<Self, Error> {
+    fn from_rng<R: CryptoRng>(rng: R) -> Result<Self, Error> {
         WordRngType::from_rng(rng).map(|rng| IsaacWordRng(rng))
     }
 }

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -13,7 +13,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use {Rng, StdRng, NewSeeded, Distribution, Default, Sample, Error};
+use {CryptoRng, Rng, StdRng, NewSeeded, Distribution, Default, Sample, Error};
 
 use reseeding::{ReseedingRng, ReseedWithNew};
 
@@ -48,6 +48,9 @@ impl Rng for ThreadRng {
         self.rng.borrow_mut().try_fill(bytes)
     }
 }
+
+// FIXME: use an inner RNG which is really a CryptoRng!
+impl CryptoRng for ThreadRng {}
 
 thread_local!(
     static THREAD_RNG_KEY: Rc<RefCell<ReseedingStdRng>> = {


### PR DESCRIPTION
This is a concept implementation with issues; see the FIXMEs.

I'm not convinced that we should do this since it's more restrictive than required to achieve the desired effects (prevent accidental clone of `XorShiftRng` and prevent seeding a strong PRNG from a weak PRNG).

The sham implementation for `ThreadRng` shows how easy it is to mis-use `CryptoRng`; I wonder if we should just rename it `StrongRng` or `NonTrivialRng` and let ISAAC implement it.