### PR TITLE
Restrict the seed type to a few more array sizes

### DIFF
--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -210,8 +210,11 @@ impl<R: Rng+?Sized> Rng for Box<R> {
 
 mod private {
     pub trait Sealed {}
+    impl Sealed for [u8; 4] {}
     impl Sealed for [u8; 8] {}
+    impl Sealed for [u8; 12] {}
     impl Sealed for [u8; 16] {}
+    impl Sealed for [u8; 24] {}
     impl Sealed for [u8; 32] {}
 }
 


### PR DESCRIPTION
I am not sure this is a good idea, but this are seed sizes I encountered with the RNG's implemented in [`small-rngs`](https://github.com/pitdicker/small-rngs).