### PR TITLE
Remove `next_u128`

### DIFF
--- a/rand_core/src/impls.rs
+++ b/rand_core/src/impls.rs
@@ -74,12 +74,6 @@ pub fn fill_bytes_via_u64<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
     fill_bytes_via!(rng, next_u64, 8, dest)
 }
 
-/// Implement `fill_bytes` via `next_u128`, little-endian order.
-#[cfg(feature = "i128_support")]
-pub fn fill_bytes_via_u128<R: Rng+?Sized>(rng: &mut R, dest: &mut [u8]) {
-    fill_bytes_via!(rng, next_u128, 16, dest)
-}
-
 macro_rules! impl_uint_from_fill {
     ($self:expr, $ty:ty, $N:expr) => ({
         debug_assert!($N == ::core::mem::size_of::<$ty>());

--- a/rand_core/src/lib.rs
+++ b/rand_core/src/lib.rs
@@ -112,10 +112,6 @@ pub trait Rng {
     /// Return the next random u64.
     fn next_u64(&mut self) -> u64;
 
-    /// Return the next random u128.
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128;
-
     /// Fill `dest` entirely with random data.
     ///
     /// This method does *not* have any requirement on how much of the
@@ -169,11 +165,6 @@ impl<'a, R: Rng+?Sized> Rng for &'a mut R {
         (**self).next_u64()
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        (**self).next_u128()
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         (**self).fill_bytes(dest)
     }
@@ -191,11 +182,6 @@ impl<R: Rng+?Sized> Rng for Box<R> {
 
     fn next_u64(&mut self) -> u64 {
         (**self).next_u64()
-    }
-
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        (**self).next_u128()
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {

--- a/src/distributions/uniform.rs
+++ b/src/distributions/uniform.rs
@@ -94,7 +94,10 @@ impl Distribution<i64> for Uniform {
 impl Distribution<i128> for Uniform {
     #[inline]
     fn sample<R: Rng+?Sized>(&self, rng: &mut R) -> i128 {
-        rng.next_u128() as i128
+        // Use LE; we explicitly generate one value before the next.
+        let x = rng.next_u64() as u128;
+        let y = rng.next_u64() as u128;
+        ((y << 64) | x) as i128
     }
 }
 
@@ -143,7 +146,10 @@ impl Distribution<u64> for Uniform {
 impl Distribution<u128> for Uniform {
     #[inline]
     fn sample<R: Rng+?Sized>(&self, rng: &mut R) -> u128 {
-        rng.next_u128()
+        // Use LE; we explicitly generate one value before the next.
+        let x = rng.next_u64() as u128;
+        let y = rng.next_u64() as u128;
+        (y << 64) | x
     }
 }
 

--- a/src/jitter.rs
+++ b/src/jitter.rs
@@ -738,11 +738,6 @@ impl Rng for JitterRng {
        self.gen_entropy()
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         impls::fill_bytes_via_u64(self, dest)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,10 +470,6 @@ impl Rng for StdRng {
     fn next_u64(&mut self) -> u64 {
         self.0.next_u64()
     }
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        self.0.next_u128()
-    }
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest);
     }
@@ -511,10 +507,6 @@ mod test {
         }
         fn next_u64(&mut self) -> u64 {
             self.inner.next_u64()
-        }
-        #[cfg(feature = "i128_support")]
-        fn next_u128(&mut self) -> u128 {
-            self.inner.next_u128()
         }
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             self.inner.fill_bytes(dest)

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -48,16 +48,13 @@ impl Rng for MockAddRng {
     fn next_u32(&mut self) -> u32 {
         self.next_u64() as u32
     }
+
     fn next_u64(&mut self) -> u64 {
         let result = self.v.0;
         self.v += self.a;
         result
     }
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-    
+
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         impls::fill_bytes_via_u64(self, dest);
     }

--- a/src/os.rs
+++ b/src/os.rs
@@ -61,11 +61,6 @@ impl Rng for OsRng {
         impls::next_u64_via_fill(self)
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_fill(self)
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         // We cannot return Err(..), so we try to handle before panicking.
         const WAIT_DUR_MS: u32 = 100;   // retry every 100ms

--- a/src/prng/chacha.rs
+++ b/src/prng/chacha.rs
@@ -196,11 +196,6 @@ impl Rng for ChaChaRng {
         impls::next_u64_via_u32(self)
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         while read_len < dest.len() {

--- a/src/prng/hc128.rs
+++ b/src/prng/hc128.rs
@@ -331,11 +331,6 @@ impl Rng for Hc128Rng {
         }
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-
     // As an optimization we try to write directly into the output buffer.
     // This is only enabled for platforms where unaligned writes are known to
     // be safe and fast.

--- a/src/prng/isaac.rs
+++ b/src/prng/isaac.rs
@@ -230,11 +230,6 @@ impl Rng for IsaacRng {
         impls::next_u64_via_u32(self)
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         while read_len < dest.len() {

--- a/src/prng/isaac64.rs
+++ b/src/prng/isaac64.rs
@@ -234,11 +234,6 @@ impl Rng for Isaac64Rng {
         value
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut read_len = 0;
         while read_len < dest.len() {

--- a/src/prng/isaac_word.rs
+++ b/src/prng/isaac_word.rs
@@ -41,11 +41,6 @@ impl Rng for IsaacWordRng {
         self.0.next_u64()
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        self.0.next_u128()
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.fill_bytes(dest)
     }

--- a/src/prng/xorshift.rs
+++ b/src/prng/xorshift.rs
@@ -73,11 +73,7 @@ impl Rng for XorShiftRng {
     fn next_u64(&mut self) -> u64 {
         impls::next_u64_via_u32(self)
     }
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_u64(self)
-    }
-    
+
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         impls::fill_bytes_via_u32(self, dest)
     }

--- a/src/read.rs
+++ b/src/read.rs
@@ -58,11 +58,6 @@ impl<R: Read> Rng for ReadRng<R> {
         impls::next_u64_via_fill(self)
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        impls::next_u128_via_fill(self)
-    }
-    
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.try_fill_bytes(dest).unwrap();
     }

--- a/src/reseeding.rs
+++ b/src/reseeding.rs
@@ -123,16 +123,6 @@ impl<R: Rng, Rsdr: Reseeder<R>> Rng for ReseedingRng<R, Rsdr> {
         value
     }
 
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        let value = self.rng.next_u128();
-        self.bytes_until_reseed -= 16;
-        if self.bytes_until_reseed <= 0 {
-            self.reseed();
-        }
-        value
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.rng.fill_bytes(dest);
         self.bytes_until_reseed -= dest.len() as i64;

--- a/src/thread_local.rs
+++ b/src/thread_local.rs
@@ -34,11 +34,6 @@ impl Rng for ThreadRng {
     fn next_u64(&mut self) -> u64 {
         self.rng.borrow_mut().next_u64()
     }
-    
-    #[cfg(feature = "i128_support")]
-    fn next_u128(&mut self) -> u128 {
-        self.rng.borrow_mut().next_u128()
-    }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.rng.borrow_mut().fill_bytes(dest);


### PR DESCRIPTION
I don't think `next_u128` is going to be all useful.

For small RNG's It is going to be difficult to get much faster on 64-bit architectures than generating two `u64`s. For cryptographic RNGs that generate values in blocks the performance overhead of reading two `u64` from the buffered results instead of one `u128` directly should be tiny.

If we start using something like SIMD or the GPU to generate random numbers we could generate more than 64 bits at a time efficiently, but is the `i128` type then the best interface? Or is it then better to work with arrays, like the proposed `BlockRng`?

Generating `u128`s is not useful for floats, one of the big uses of random numbers. And the uses of `u128`s are not that many either.